### PR TITLE
feat(api): Add support for get initialized status

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -37,4 +37,12 @@ Vaulted.init = function init(options) {
     });
 };
 
-
+/**
+ * Gets the initialize status of a vault
+ *
+ * @return {Promise<Vaulted>} Promise which is resolved with the vault initializtion status.
+ */
+Vaulted.getInitStatus = function getInitStatus() {
+  return this.api.getEndpoint('sys/init')
+    .get();
+};

--- a/tests/init.js
+++ b/tests/init.js
@@ -1,0 +1,40 @@
+require('./helpers.js').should;
+
+var
+  chai = require('./helpers').chai,
+  Vault = require('../lib/vaulted.js');
+
+chai.use(require('./helpers').cap);
+
+describe('init', function() {
+  var myVault = null;
+
+  before(function() {
+    myVault = new Vault({vault_ssl: 0});
+  });
+
+  it('initialized false', function () {
+    myVault.getInitStatus().then(function (result) {
+        result.initialized.should.be.false;
+    });
+  });
+
+  it('init successful', function () {
+    myVault.init().then(function (result) {
+        result.should.be.an.instanceof(Vault);
+    });
+  });
+
+  it('init failed - already initialized', function () {
+    myVault.init().then(null, function (err) {
+        err.should.be.an.instanceof(Error);
+    });
+  });
+
+  it('initialized true', function () {
+    myVault.getInitStatus().then(function (result) {
+        result.initialized.should.be.true;
+    });
+  });
+
+});


### PR DESCRIPTION
The endpoint GET /sys/init was already defined but not exposed
for use. An API getInitStatus is now available for use to verify
if the vault has been initialized or not.

Tests for each of the init APIs have been added to validate the
functionality. Testing will now require a functional instance
of vault running. To test make sure the vault binary is available
on the local path and run `vault server -config=config/dev.hcl`
