### PR TITLE
chore(tests): Test and document core

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -5,6 +5,12 @@ var
 
 module.exports = API;
 
+/**
+ * API constructor
+ *
+ * @constructor
+ * @param {Object} config overrides any configuration set by node-convict setup.
+ */
 function API(config) {
   if(_.isUndefined(config) || _.isUndefined(config.get)) {
     throw new Error('API must be instantiated with a node-convict based object');
@@ -51,22 +57,22 @@ API.prototype._loadAPIDefinitions = function _loadAPIDefinitions(config) {
 };
 
 API.prototype._getDefinition = function _getDefinition(api_type) {
-  api_type = _.isString(api_type) ? api_type : 'sys';
-  var api;
-  try {
-    api = this[api_type];
-    if (_.isUndefined(api)) {
-      throw new Error('API definition is undefined');
-    }
-  } catch (ex) {
-    throw new Error('Could not get API for \"' + api_type + '\"' + '\n' + ex.message);
+  var api = _.get(this, api_type);
+  if (_.isUndefined(api)) {
+    throw new Error('Could not get API for \"' + api_type + '\"');
   }
   return api;
 };
 
+/**
+ * Retrieves the named endpoint.
+ *
+ * @param {String} endpoint the name / path of the defined endpoint.
+ * @return {EndPoint} An instance matching the specificed name.
+ */
 API.prototype.getEndpoint = function getEndpoint(endpoint_name) {
   if (!_.isString(endpoint_name) || endpoint_name.length === 0) {
-    throw new Error('Can not get endpoint for non-string value: ' + endpoint_name);
+    throw new Error('Endpoint not provided or has no length.');
   }
   var
     endpoint_info = endpoint_name.split('/'),
@@ -80,4 +86,3 @@ API.prototype.getEndpoint = function getEndpoint(endpoint_name) {
   }
   return endpoint;
 };
-

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,8 @@
 var
   _ = require('lodash'),
-  convict = require('convict');
+  convict = require('convict'),
+  os = require('os'),
+  path = require('path');
 
 module.exports = config;
 
@@ -73,6 +75,12 @@ function config(config_obj) {
         'config/api_auth_token.json',
         'config/api_secret.json'
       ]
+    },
+    backup_dir: {
+      doc: 'Directory to backup keys',
+      format: String,
+      default: path.join(os.homedir(), '.vault'),
+      env: 'VAULT_SAFE'
     }
   });
 

--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -3,6 +3,13 @@ var
   rp = require('request-promise'),
   Promise = require('bluebird');
 
+/**
+ * Setup function for Endpoint module; provides debug support and returns
+ * the Endpoint class.
+ *
+ * @param {Object} config overrides any configuration set by node-convict setup.
+ * @return {Endpoint} Endpoint class reference
+ */
 module.exports = function setup(config) {
   config = config || {};
   if(_.isFunction(config.get) && config.get('debug') === 1) {
@@ -22,6 +29,12 @@ function reduceVerbs(verbs, cur_verb) {
     return verbs;
 }
 
+/**
+ * Endpoint constructor
+ *
+ * @constructor
+ * @param  {Object} options Hash of options create the Endpoint, keys "name", "verbs", "base_url" required.
+ */
 function Endpoint(options) {
   options = options || {};
   options.verbs = _.isArray(options.verbs) ? options.verbs : [];
@@ -43,12 +56,25 @@ function Endpoint(options) {
   this.server_url = options.base_url;
 }
 
+/**
+ * Helper function to create a new instance of Endpoint
+ *
+ * @param  {String} url base url for the endpoint
+ * @param  {Object} options Hash of options create the Endpoint, keys "name", "verbs", "base_url" required.
+ * @return {Endpoint} new instance of Endpoint
+ */
 Endpoint.create = function create(url, options) {
   return new Endpoint(_.defaults(options, {
     base_url: url
   }));
 };
 
+/**
+ * Generates a formatted url for the Endpoint
+ *
+ * @param  {Object} options Hash of options, keys "id" supported.
+ * @return {Endpoint} new instance of Endpoint
+ */
 Endpoint.prototype.getURI = function getURL(options) {
   options = options || {};
   var name = this.name;

--- a/lib/init.js
+++ b/lib/init.js
@@ -1,8 +1,8 @@
-
 var
   Vaulted = {},
   Promise = require('bluebird'),
-  _ = require('lodash');
+  _ = require('lodash'),
+  internal = require('./internal');
 
 module.exports = function extend(Proto) {
   _.extend(Proto, Vaulted);
@@ -14,9 +14,9 @@ module.exports = function extend(Proto) {
  * @param  {Object}   options   Overrides sent to API command, 'secret_shares' and 'secret_threshold', both {Number}
  * @return {Promise}  Promise which is resolved with current instance of Vaulted. Populates keys and tokens properties.
  */
-Vaulted.init = function init(options) {
+Vaulted.init = Promise.method(function init(options) {
   if (this.initialized === true) {
-    return Promise.reject(new Error('Vault is already initialized.'));
+    return Promise.resolve(this);
   }
 
   options = _.defaults(options || {}, {
@@ -31,10 +31,18 @@ Vaulted.init = function init(options) {
     .promise()
     .bind(this)
     .then(function keysAndToken(keys_and_token) {
-      this.keys = keys_and_token.keys;
-      this.initialized = true;
-      return this.setToken(keys_and_token.root_token);
+      this.setKeys(keys_and_token.keys);
+      this.setToken(keys_and_token.root_token);
+      return internal.backup(this);
     });
-};
+});
 
-
+/**
+ * Gets the initialize status of a vault
+ *
+ * @return {Promise<Vaulted>} Promise which is resolved with the vault initializtion status.
+ */
+Vaulted.getInitStatus = Promise.method(function getInitStatus() {
+  return this.api.getEndpoint('sys/init')
+    .get();
+});

--- a/lib/internal.js
+++ b/lib/internal.js
@@ -1,0 +1,100 @@
+var
+  _ = require('lodash'),
+  Promise = require('bluebird'),
+  mkdirp = Promise.promisifyAll(require('mkdirp')),
+  fs = Promise.promisifyAll(require('fs')),
+  path = require('path'),
+  debuglog = require('util').debuglog('vaulted');
+
+
+var internal = module.exports;
+
+function checkStatus(vault, status) {
+  if (!status.initialized || !_.isArray(vault.keys) || vault.keys.length === 0) {
+    debuglog('either vault not initialized or no keys found');
+    return vault;
+  }
+  return vault.getSealedStatus().bind(vault)
+    .then(vault.getMounts)
+    .then(function () {
+      debuglog('internal state loaded');
+      return vault;
+    }).
+    catch(function onError(err) {
+      debuglog('failed to retrieve mounts: %s', err.message);
+      return vault;
+    });
+}
+
+
+/**
+ * Load retrieve the current state of the vault and sets internal properties accordingly
+ *
+ * @param  {Vaulted} vault an instance of Vaulted.
+ * @return {Promise<Vaulted>} Promise which is resolved with current instance of Vaulted.
+ */
+internal.loadState = function loadState(vault) {
+  return this.recover(vault).bind(vault)
+    .then(vault.getInitStatus)
+    .then(_.partial(checkStatus, vault));
+};
+
+/**
+ * Save the internal state to a file.
+ *
+ * @param  {Vaulted} vault an instance of Vaulted.
+ * @return {Promise<Vaulted>} Promise which is resolved with current instance of Vaulted.
+ */
+internal.backup = function backup(vault) {
+  var backupFile = path.join(vault.config.get('backup_dir'), 'keys.json');
+  var ownmode = {mode: parseInt('0700', 8)};
+  var data = JSON.stringify({root: vault.token, keys: vault.keys});
+
+  if (!_.isString(vault.token) || !_.isArray(vault.keys) || vault.keys.length === 0) {
+    debuglog('no data to backup');
+    return Promise.resolve(vault);
+  }
+
+  return mkdirp.mkdirpAsync(vault.config.get('backup_dir'), ownmode).then(function () {
+    return fs.writeFileAsync(backupFile, data, ownmode).then(function () {
+      debuglog('backup file written');
+      return vault;
+    });
+  }).catch(function (err) {
+    debuglog('failed to save keys: %s', err.message);
+    return vault;
+  });
+};
+
+/**
+ * Retrieve the internal state from backup file.
+ *
+ * @param  {Vaulted} vault an instance of Vaulted.
+ * @return {Promise<Vaulted>} Promise which is resolved with current instance of Vaulted.
+ */
+internal.recover = function recover(vault) {
+  var backupFile = path.join(vault.config.get('backup_dir'), 'keys.json');
+
+  return fs.readFileAsync(backupFile)
+  .then(JSON.parse)
+  .then(function (data) {
+    if (_.isString(data.root) && _.isArray(data.keys) && data.keys.length > 0) {
+      vault.setToken(data.root);
+      vault.setKeys(data.keys);
+      debuglog('recover successful');
+    }
+    return vault;
+  })
+  .catch(SyntaxError, function (err) {
+    // invalid file (someone been modifying it?)
+    debuglog('failed to recover backup: %s', err.message);
+    return vault;
+  })
+  .catch(function (err) {
+    // file most likely does not exist so just ignore it.
+    if (err.code !== 'ENOENT') {
+      debuglog('unable to read backup: %s', err.message);
+    }
+    return vault;
+  });
+};

--- a/lib/mounts.js
+++ b/lib/mounts.js
@@ -9,7 +9,12 @@ module.exports = function extend(Proto) {
   _.extend(Proto, Vaulted);
 };
 
-Vaulted.getMounts = function getMounts() {
+/**
+ * Gets the list of mounts for the vault and sets internal property accordingly
+ *
+ * @return {Promise<Vaulted>} Promise which is resolved with current instance of Vaulted with 'mounts' property updated.
+ */
+Vaulted.getMounts = Promise.method(function getMounts() {
   return this.getMountsEndpoint()
     .get({
       headers: this.headers
@@ -20,10 +25,20 @@ Vaulted.getMounts = function getMounts() {
       this.mounts = mounts;
       return this.mounts;
     });
-};
+});
 
-Vaulted.deleteMount = function deleteMount(options) {
+/**
+ * Deletes the specified mount from the vault and sets internal property accordingly
+ *
+ * @param  {Object} options Hash of options to send to API request, key "id" required.
+ * @return {Promise<Vaulted>} Promise which is resolved with current instance of Vaulted with 'mounts' property updated.
+ */
+Vaulted.deleteMount = Promise.method(function deleteMount(options) {
   options = options || {};
+  if (_.isUndefined(options.id) || !options.id) {
+    return Promise.reject(new Error('You must provide mount id.'));
+  }
+
   return this.getMountsEndpoint()
     .delete({
       id: options.id,
@@ -31,68 +46,74 @@ Vaulted.deleteMount = function deleteMount(options) {
     })
     .promise()
     .bind(this)
-    .then(function deletedMount() {
-      delete this.mounts[options.id];
-      return this;
-    });
-};
+    .then(this.getMounts);
+});
 
-Vaulted.createMount = function createMount(options) {
-  options = options || { body: null, id: null };
-  var new_mount = {
-    type: options.body.type,
-    description: options.body.description
-  };
+/**
+ * Creates the specified mount in the vault and sets internal property accordingly
+ *
+ * @param  {Object} options Hash of options to send to API request, keys "id" and "body" required.
+ * @return {Promise<Vaulted>} Promise which is resolved with current instance of Vaulted with 'mounts' property updated.
+ */
+Vaulted.createMount = Promise.method(function createMount(options) {
+  options = options || {};
+  if (_.isUndefined(options.id) || !options.id) {
+    return Promise.reject(new Error('You must provide mount id.'));
+  }
+
+  if (_.isUndefined(options.body) || !options.body) {
+    return Promise.reject(new Error('You must provide mount details.'));
+  }
+
+  if (_.isUndefined(options.body.type) || !options.body.type) {
+    return Promise.reject(new Error('You must provide mount type.'));
+  }
+
   return this.getMountsEndpoint()
     .post({
       headers: this.headers,
       id: options.id,
-      body: new_mount
-    })
-    .promise()
-    .bind(this)
-    .then(function createdMount() {
-      this.mounts[options.id+'/'] = new_mount;
-      return this.mounts;
-    });
-};
-
-Vaulted.reMount = function reMount(options) {
-  options = options || {};
-  var
-    to_mount = options.to,
-    from_mount;
-
-  try {
-    if( _.isUndefined(to_mount) || to_mount.length === 0) {
-      throw new Error('No "to" parameter sent');
-    }
-    if(_.isUndefined(options.from) || options.from.length === 0) {
-      throw new Error('No "from" parameter sent');
-    }
-    from_mount = this.mounts[options.from + '/'];
-    if(_.isUndefined(from_mount)) {
-      throw new Error();
-    }
-  } catch(ex) {
-    return Promise.reject(new Error('Could not find existing mount named: ' + options.from));
-  }
-  return this.getRemountEndpoint()
-    .post({
-      headers: this.headers,
       body: {
-        from: options.from,
-        to: to_mount
+        type: options.body.type,
+        description: options.body.description
       }
     })
     .promise()
     .bind(this)
-    .then(function remounted() {
-      var from = options.from + '/';
-      this.mounts[to_mount + '/'] = this.mounts[from];
-      delete this.mounts[from];
-      return this.mounts;
-    });
-};
+    .then(this.getMounts);
+});
 
+/**
+ * Renames the specified mount to a new name in the vault and sets internal property accordingly
+ *
+ * @param  {Object} options Hash of options to send to API request, keys "from" and "to" required.
+ * @return {Promise<Vaulted>} Promise which is resolved with current instance of Vaulted with 'mounts' property updated.
+ */
+Vaulted.reMount = Promise.method(function reMount(options) {
+  options = options || {};
+  if(_.isUndefined(options.from) || !options.from) {
+    return Promise.reject(new Error('You must provide from mount.'));
+  }
 
+  if(_.isUndefined(options.to) || !options.to) {
+    return Promise.reject(new Error('You must provide to mount.'));
+  }
+
+  // make sure the mount exists but the user could pass in the mount
+  // id with or without the forward slash and if we are unable to
+  // find it using either variation then reject the request.
+  if(_.isUndefined(this.mounts[options.from]) && _.isUndefined(
+    this.mounts[options.from + '/'])) {
+    return Promise.reject(
+      new Error('Could not find existing mount named: ' + options.from));
+  }
+
+  return this.getRemountEndpoint()
+    .post({
+      headers: this.headers,
+      body: options
+    })
+    .promise()
+    .bind(this)
+    .then(this.getMounts);
+});

--- a/lib/seal.js
+++ b/lib/seal.js
@@ -1,6 +1,7 @@
 
 var
   Vaulted = {},
+  Promise = require('bluebird'),
   _ = require('lodash');
 
 module.exports = function extend(Proto) {
@@ -12,37 +13,41 @@ module.exports = function extend(Proto) {
  *
  * @return {Promise<Vaulted>} Promise which is resolved with current instance of Vaulted with 'status' property updated.
  */
-Vaulted.getSealedStatus = function getSealedStatus() {
-  this.api.getEndpoint('sys/seal-status')
+Vaulted.getSealedStatus = Promise.method(function getSealedStatus() {
+  return this.api.getEndpoint('sys/seal-status')
     .get()
     .promise()
     .bind(this)
     .then(this.setStatus);
-};
+});
 
 /**
  * Seals the vault
  *
  * @return {Promise<Vaulted>} promise is resolved with bound instance
  */
-Vaulted.seal = function() {
+Vaulted.seal = Promise.method(function() {
   if (!this.initialized) {
     return Promise.reject(new Error('Vault has not been initialized.'));
   }
   if (this.status.sealed) {
     return Promise.resolve(this);
   }
-  this.api.getEndpoint('sys/seal')
-    .put()
+  return this.api.getEndpoint('sys/seal')
+    .put({
+      headers: this.headers
+    })
     .promise()
     .bind(this)
-    .then(function setSealed() {
-      this.status.sealed = true;
-      return this;
-    });
-};
+    .then(this.getSealedStatus);
+});
 
-Vaulted.unSeal = function unSeal() {
+/**
+ * Unseals the vault
+ *
+ * @return {Promise<Vaulted>} promise is resolved with bound instance
+ */
+Vaulted.unSeal = Promise.method(function unSeal() {
   if (!this.initialized) {
     return Promise.reject(new Error('Vault has not been initialized.'));
   }
@@ -59,5 +64,4 @@ Vaulted.unSeal = function unSeal() {
     .bind(this)
     .then(this.setStatus)
     .then(this.unSeal);
-};
-
+});

--- a/lib/secret.js
+++ b/lib/secret.js
@@ -1,4 +1,3 @@
-
 var
   Vaulted = {},
   Promise = require('bluebird'),
@@ -13,11 +12,14 @@ module.exports = function extend(Proto) {
  * Write a secret to the generic backend
  *
  * @param  {Object} options Hash of options to send to API request, keys "id" and "body" required.
- * @return {Promise<Object>}         Promise which resolves with secret object returned from server
+ * @return {Promise<Object>} Promise which resolves with secret object returned from server
  */
-Vaulted.write = function writeSecret(options) {
+Vaulted.write = Promise.method(function writeSecret(options) {
   options = options || {};
-  if (_.isUndefined(options.body)) {
+  if (_.isUndefined(options.id) || !options.id) {
+    return Promise.reject(new Error('You must provide secret id.'));
+  }
+  if (_.isUndefined(options.body)  || !options.body) {
     return Promise.reject(new Error('You must provide an secret to write to the Vault.'));
   }
   return this.getSecretEndpoint()
@@ -26,36 +28,40 @@ Vaulted.write = function writeSecret(options) {
       id: options.id,
       body: options.body
     });
-};
+});
 
 /**
  * Read / get a secret from the generic backend
  *
  * @param  {Object} options Options hash, "id" is required
- * @return {Promise<Object>}         Promise which resolves to the secret or rejects when secret is not found
+ * @return {Promise<Object>} Promise which resolves to the secret or rejects when secret is not found
  */
-Vaulted.read = function readSecret(options) {
+Vaulted.read = Promise.method(function readSecret(options) {
   options = options || {};
+  if (_.isUndefined(options.id) || !options.id) {
+    return Promise.reject(new Error('You must provide secret id.'));
+  }
   return this.getSecretEndpoint()
     .get({
       headers: this.headers,
       id: options.id
     });
-};
+});
 
 /**
  * Delete a secret from the generic backend
  *
  * @param  {Object} options Options hash, "id" is required
- * @return {Promise<Object>}         Promise which resolves with status of deletion
+ * @return {Promise<Object>} Promise which resolves with status of deletion
  */
-Vaulted.delete = function deleteSecret(options) {
+Vaulted.delete = Promise.method(function deleteSecret(options) {
   options = options || {};
+  if (_.isUndefined(options.id) || !options.id) {
+    return Promise.reject(new Error('You must provide secret id.'));
+  }
   return this.getSecretEndpoint()
     .delete({
       headers: this.headers,
       id: options.id
     });
-};
-
-
+});

--- a/lib/vaulted.js
+++ b/lib/vaulted.js
@@ -1,7 +1,7 @@
 var
   _ = require('lodash'),
-  Promise = require('bluebird'),
   create_config = require('./config.js'),
+  internal = require('./internal'),
   API = require('./api.js');
 
 module.exports = Vaulted;
@@ -20,10 +20,21 @@ function Vaulted(config) {
   this.status = {
     sealed: true
   };
+  this.token = null;
+  this.keys = [];
   this.mounts = {};
   this.headers = {};
   this.initialized = false;
 }
+
+/**
+ * Attempt to load the Vault state.
+ *
+ * @return {Promise<Vaulted>} promise is resolved with bound instance
+ */
+Vaulted.prototype.prepare = function prepare() {
+  return internal.loadState(this);
+};
 
 /**
  * Sets the token to use when accessing the vault,
@@ -44,22 +55,43 @@ Vaulted.prototype.setToken = function setToken(vault_token) {
 };
 
 /**
+ * Sets the keys to use when sealing and unsealing the vault.
+ *
+ * @param {Array} keys
+ * @returns {Vaulted} returns bound instance
+ */
+Vaulted.prototype.setKeys = function setKeys(keys) {
+  if (!_.isArray(keys) || keys.length === 0) {
+    throw new Error('Vault keys not provided, or is empty list.');
+  }
+
+  this.keys = keys;
+  // having keys means being initialized
+  this.initialized = true;
+
+  return this;
+};
+
+/**
  * Set status hash
  *
  * @param {Object} status Object representing status, which includes 'sealed' property.
  * @return {Vaulted} Current instance
  */
 Vaulted.prototype.setStatus = function setStatus(status) {
-  status = status || {};
-  this.status = status;
+  if (_.isPlainObject(status) && _.has(status, 'sealed')) {
+    this.status = status;
+  }
   return this;
 };
 
-
+/**
+ * Validate the request endpoint and that the Vault is prepared for use.
+ *
+ * @param {String} endpoint the name / path of the defined endpoint.
+ * @return {EndPoint} An instance matching the specificed name.
+ */
 Vaulted.prototype.validateEndpoint = function validateEndpoint(endpoint) {
-  if(!_.isString(endpoint) || endpoint.length === 0) {
-    throw new Error('Endpoint not provided or has no length.');
-  }
   if (!this.initialized) {
     throw new Error('Vault has not been initialized.');
   }
@@ -74,6 +106,3 @@ require('./seal')(Vaulted.prototype);
 require('./init')(Vaulted.prototype);
 require('./secret')(Vaulted.prototype);
 require('./mounts')(Vaulted.prototype);
-
-
-

--- a/package.json
+++ b/package.json
@@ -19,11 +19,12 @@
   "author": "Christopher 'Chief' Najewicz <chief@beefdisciple.com>",
   "license": "MIT",
   "dependencies": {
-    "bluebird": "^2.9.34",
-    "convict": "^0.8.0",
-    "lodash": "^3.9.3",
-    "request-promise": "^0.4.3",
-    "request-debug": "^0.2.0"
+    "bluebird": "^3.0.0",
+    "convict": "^1.0.1",
+    "lodash": "^3.10.0",
+    "request-promise": "^1.0.2",
+    "request-debug": "^0.2.0",
+    "mkdirp": "^0.5.1"
   },
   "devDependencies": {
     "chai": "^3.0.0",

--- a/tests/api.js
+++ b/tests/api.js
@@ -14,7 +14,7 @@ describe('API', function() {
     it('should throw when no params are sent', function () {
       (function() {
         new API();
-      }).should.throw(Error);
+      }).should.throw(/API must be instantiated with a node-convict based object/);
     });
 
   });
@@ -30,14 +30,21 @@ describe('API', function() {
       function shouldThrow() {
         myAPI.getEndpoint();
       }
-      shouldThrow.should.throw(/Can not get endpoint for non-string value/);
+      shouldThrow.should.throw(/Endpoint not provided or has no length/);
     });
 
     it('should throw error if endpoint name empty', function () {
       function shouldThrow() {
         myAPI.getEndpoint('');
       }
-      shouldThrow.should.throw(/Can not get endpoint for non-string value/);
+      shouldThrow.should.throw(/Endpoint not provided or has no length/);
+    });
+
+    it('should throw error if endpoint unknown', function () {
+      function shouldThrow() {
+        myAPI.getEndpoint('sys/fake');
+      }
+      shouldThrow.should.throw(/Could not find endpoint/);
     });
 
   });
@@ -53,7 +60,7 @@ describe('API', function() {
       (function() {
         config.set('prefix', null);
         new API(config);
-      }).should.throw(Error);
+      }).should.throw(/Could not get API version to load defintion file/);
     });
 
     afterEach(function () {
@@ -75,14 +82,14 @@ describe('API', function() {
       (function() {
         var bad_path = 'config/asdfasdf.json';
         API.prototype._readConfigFromPath.call(null, config, {}, bad_path);
-      }).should.throw(Error);
+      }).should.throw(/Invalid file name at/);
     });
 
     it('should throw exception if the api definition file contains invalid JSON', function () {
       (function() {
         var bad_path = 'tests/configs/bad_json.json';
         API.prototype._readConfigFromPath.call(null, config, {}, bad_path);
-      }).should.throw('Could not read API definition file');
+      }).should.throw(/Could not read API definition file/);
     });
 
     it('should load a well formed JSON doc with the correct filename', function () {
@@ -96,7 +103,7 @@ describe('API', function() {
       (function() {
         config.set('prefix', 'someprefix');
         new API(config);
-      }).should.throw(Error);
+      }).should.throw(/Could not find API definition/);
     });
 
     afterEach(function () {

--- a/tests/endpoint.js
+++ b/tests/endpoint.js
@@ -1,12 +1,18 @@
 require('./helpers.js').should;
 
 var
-  chai = require('./helpers').chai,
+  debuglog = require('util').debuglog('vaulted-tests'),
+  helpers = require('./helpers'),
+  chai = helpers.chai,
   _ = require('lodash'),
   fs = require('fs'),
   Endpoint = require('../lib/endpoint.js')();
 
-chai.use(require('./helpers').cap);
+chai.use(helpers.cap);
+var VAULT_HOST = helpers.VAULT_HOST;
+var VAULT_PORT = helpers.VAULT_PORT;
+var BASE_URL = 'http://' + VAULT_HOST + ':' + VAULT_PORT;
+
 
 describe('Endpoint', function() {
 
@@ -18,7 +24,7 @@ describe('Endpoint', function() {
     var endpoint;
 
     beforeEach(function() {
-      var options = _.defaults(api_def[0],{ base_url: 'http://localhost:8200'});
+      var options = _.defaults(api_def[0],{ base_url: BASE_URL });
       endpoint = new Endpoint(options);
     });
 
@@ -58,7 +64,7 @@ describe('Endpoint', function() {
     var endpoint, options;
 
     beforeEach(function() {
-      options = _.extend(api_def[0], { base_url: 'https://localhost:8200' });
+      options = _.extend(api_def[0], { base_url: BASE_URL });
       endpoint = new Endpoint(options);
     });
 
@@ -69,14 +75,14 @@ describe('Endpoint', function() {
 
     it('should append the endpoint to the base uri', function () {
       var endpoint_uri = endpoint.getURI();
-      endpoint_uri.should.equal('https://localhost:8200/punts');
+      endpoint_uri.should.equal(BASE_URL + '/punts');
     });
 
     it('should replace :id with provided option id', function () {
-      options = _.extend(api_def[3], { base_url: 'https://localhost:8200' });
+      options = _.extend(api_def[3], { base_url: BASE_URL });
       endpoint = new Endpoint(options);
       var endpoint_uri = endpoint.getURI({id: 'test'});
-      endpoint_uri.should.equal('https://localhost:8200/sys/no_get/test');
+      endpoint_uri.should.equal(BASE_URL + '/sys/no_get/test');
     });
   });
 
@@ -84,7 +90,7 @@ describe('Endpoint', function() {
     var endpoint, options;
 
     beforeEach(function() {
-      options = _.extend(api_def[0], { base_url: 'https://localhost:8200' });
+      options = _.extend(api_def[0], { base_url: BASE_URL });
       endpoint = new Endpoint(options);
     });
 
@@ -109,19 +115,21 @@ describe('Endpoint', function() {
     });
 
     it('should reject the promise if the endpoint does not support the verb', function() {
-      endpoint = new Endpoint(_.extend(api_def[2], { base_url: 'https://localhost:8200' }));
-      endpoint.get().should.be.rejectedWith(Error);
+      endpoint = new Endpoint(_.extend(api_def[2], { base_url: BASE_URL }));
+      endpoint.get().should.be.rejectedWith(/Could not find method/);
     });
 
     it('should return a promise if the endpoint supports the verb', function() {
-      endpoint = new Endpoint(api_def[0]);
-      endpoint.get().should.be.fufilled;
+      debuglog('server_url: ', endpoint.server_url);
+      // promise is returned but it is rejected since the route does not actually
+      // exist within the vault server.
+      endpoint.get().should.be.rejectedWith(/404 page not found/);
     });
 
     it('should reject promise if endpoint requires id and one is not provided', function () {
-      options = _.extend(api_def[3], { base_url: 'https://localhost:8200' });
+      options = _.extend(api_def[3], { base_url: BASE_URL });
       endpoint = new Endpoint(options);
-      endpoint.put().should.be.rejectedWith(Error);
+      endpoint.put().should.be.rejectedWith(/requires an id, none was given/);
     });
 
   });

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,7 +1,9 @@
 module.exports = {
   chai: require('chai'),
+  assert: require('chai').assert,
+  expect: require('chai').expect,
   should: require('chai').should(),
-  cap: require('chai-as-promised')
+  cap: require('chai-as-promised'),
+  VAULT_HOST: process.env.VAULT_HOST || 'vault',
+  VAULT_PORT: process.env.VAULT_PORT || 8200
 };
-
-

--- a/tests/init.js
+++ b/tests/init.js
@@ -1,0 +1,60 @@
+require('./helpers.js').should;
+
+var
+  helpers = require('./helpers'),
+  debuglog = require('util').debuglog('vaulted-tests'),
+  chai = helpers.chai,
+  assert = helpers.assert,
+  Vault = require('../lib/vaulted.js');
+
+chai.use(helpers.cap);
+
+var VAULT_HOST = helpers.VAULT_HOST;
+var VAULT_PORT = helpers.VAULT_PORT;
+
+describe('init', function() {
+  var myVault = null;
+
+  before(function() {
+    myVault = new Vault({
+      vault_host: VAULT_HOST,
+      vault_port: VAULT_PORT,
+      vault_ssl: 0
+    });
+    return myVault.prepare();
+  });
+
+  it.skip('initialized false', function () {
+    return myVault.getInitStatus().then(function (result) {
+        result.initialized.should.be.false;
+    });
+  });
+
+  it('init successful', function () {
+    return myVault.init().then(function (self) {
+        self.should.be.an.instanceof(Vault);
+        self.initialized.should.be.true;
+        self.token.should.not.be.null;
+        self.keys.should.not.be.empty;
+    }).then(null, function (err) {
+      debuglog(err);
+      assert.notOk(err, 'no error should ever be returned');
+    });
+  });
+
+  it('init - already initialized', function () {
+    return myVault.init().then(function (self) {
+        self.should.be.an.instanceof(Vault);
+        self.initialized.should.be.true;
+        self.token.should.not.be.null;
+        self.keys.should.not.be.empty;
+    });
+  });
+
+  it('initialized true', function () {
+    return myVault.getInitStatus().then(function (result) {
+        result.initialized.should.be.true;
+    });
+  });
+
+});

--- a/tests/internal.js
+++ b/tests/internal.js
@@ -1,0 +1,304 @@
+require('./helpers.js').should;
+
+var
+  helpers = require('./helpers'),
+  debuglog = require('util').debuglog('vaulted-tests'),
+  fs = require('fs'),
+  os = require('os'),
+  path = require('path'),
+  chai = helpers.chai,
+  assert = helpers.assert,
+  expect = helpers.expect,
+  Vault = require('../lib/vaulted'),
+  internal = require('../lib/internal');
+
+chai.use(helpers.cap);
+
+var VAULT_HOST = helpers.VAULT_HOST;
+var VAULT_PORT = helpers.VAULT_PORT;
+var BACKUP_DIR = path.join(os.homedir(), '.vault');
+var BACKUP_FILE = path.join(BACKUP_DIR, 'keys.json');
+
+var renameFile = function (oldname, newname) {
+  try {
+    fs.renameSync(path.join(BACKUP_DIR, oldname), path.join(BACKUP_DIR, newname));
+  } catch (err) {
+    debuglog('failed to rename %s to %s: %s', oldname, newname, err);
+  }
+};
+
+var initOrRename = function (vault, oldname, newname) {
+  return vault.getInitStatus().then(function (result) {
+    debuglog('initOrRename result status: %s', result.initialized);
+    if (!result.initialized) {
+      debuglog('calling init...');
+      return vault.init();
+    } else {
+      renameFile(oldname, newname);
+      return internal.recover(vault);
+    }
+  });
+
+};
+
+
+describe('internal state', function () {
+  var myVault = null;
+
+  before(function () {
+    myVault = new Vault({
+      vault_host: VAULT_HOST,
+      vault_port: VAULT_PORT,
+      vault_ssl: 0
+    });
+  });
+
+  it('loadState - not initialized', function () {
+    renameFile('keys.json', 'prev-keys.json');
+    return internal.loadState(myVault).then(function (self) {
+      self.initialized.should.be.false;
+      myVault.initialized.should.be.false;
+      self.keys.should.be.empty;
+      myVault.keys.should.be.empty;
+    }).then(null, function (err) {
+      debuglog(err);
+      assert.notOk(err, 'no error should ever be returned');
+    });
+  });
+
+  it('loadState - sealed', function () {
+    return initOrRename(myVault, 'prev-keys.json', 'keys.json').then(function () {
+      return internal.loadState(myVault).then(function (self) {
+        self.initialized.should.be.true;
+        myVault.initialized.should.be.true;
+        self.status.sealed.should.be.true;
+        myVault.status.sealed.should.be.true;
+      }).then(null, function (err) {
+        debuglog(err);
+        assert.notOk(err, 'no error should ever be returned');
+      });
+    }).then(null, function (err) {
+      debuglog(err);
+      assert.notOk(err, 'failed to init vault');
+    });
+  });
+
+  it('loadState - unsealed', function () {
+    return myVault.unSeal().then(function () {
+      return internal.loadState(myVault).then(function (self) {
+        self.initialized.should.be.true;
+        myVault.initialized.should.be.true;
+        self.status.sealed.should.be.false;
+        myVault.status.sealed.should.be.false;
+      }).then(null, function (err) {
+        debuglog(err);
+        assert.notOk(err, 'no error should ever be returned');
+      });
+    });
+  });
+
+  it('loadState - default mounts only', function () {
+    return internal.loadState(myVault).then(function (self) {
+      self.initialized.should.be.true;
+      myVault.initialized.should.be.true;
+      self.status.sealed.should.be.false;
+      myVault.status.sealed.should.be.false;
+      self.mounts.should.not.be.empty;
+      myVault.mounts.should.not.be.empty;
+      self.mounts.should.contain.keys('sys/');
+      myVault.mounts.should.contain.keys('sys/');
+    }).then(null, function (err) {
+      debuglog(err);
+      assert.notOk(err, 'no error should ever be returned');
+    });
+  });
+
+  it('loadState - consul mounted', function () {
+    return myVault.createMount({
+      id: 'consul',
+      body: {
+        type: 'consul'
+      }
+    }).then(function () {
+      return internal.loadState(myVault).then(function (self) {
+        self.initialized.should.be.true;
+        myVault.initialized.should.be.true;
+        self.status.sealed.should.be.false;
+        myVault.status.sealed.should.be.false;
+        self.mounts.should.not.be.empty;
+        myVault.mounts.should.not.be.empty;
+        self.mounts.should.contain.keys('consul/');
+        myVault.mounts.should.contain.keys('consul/');
+      }).then(null, function (err) {
+        debuglog(err);
+        assert.notOk(err, 'no error should ever be returned');
+      });
+    });
+  });
+
+  it('loadState - initialized with no backup', function () {
+    renameFile('keys.json', 'prev-keys.json');
+    myVault.keys = [];
+    return internal.loadState(myVault).then(function (self) {
+      self.initialized.should.be.true;
+      myVault.initialized.should.be.true;
+      self.keys.should.be.empty;
+      myVault.keys.should.be.empty;
+    }).then(null, function (err) {
+      debuglog(err);
+      assert.notOk(err, 'no error should ever be returned');
+    });
+  });
+
+  it('backup - no data', function () {
+    myVault.token = null;
+    myVault.keys = [];
+    return internal.backup(myVault).then(function () {
+      try {
+        var stats = fs.statSync(BACKUP_FILE);
+        assert.notOk(stats, 'file should not exist');
+      } catch (err) {
+        err.should.be.an.instanceof(Error);
+        err.code.should.equal('ENOENT');
+      }
+    }).then(null, function (err) {
+      debuglog(err);
+      assert.notOk(err, 'no error should ever be returned');
+    });
+  });
+
+  it('backup - keys not Array', function () {
+    myVault.keys = null;
+    return internal.backup(myVault).then(function () {
+      try {
+        var stats = fs.statSync(BACKUP_FILE);
+        assert.notOk(stats, 'file should not exist');
+      } catch (err) {
+        err.should.be.an.instanceof(Error);
+        err.code.should.equal('ENOENT');
+      }
+      myVault.keys = [];
+    }).then(null, function (err) {
+      debuglog(err);
+      assert.notOk(err, 'no error should ever be returned');
+    });
+  });
+
+  it('backup - keys empty Array', function () {
+    return internal.backup(myVault).then(function () {
+      try {
+        var stats = fs.statSync(BACKUP_FILE);
+        assert.notOk(stats, 'file should not exist');
+      } catch (err) {
+        err.should.be.an.instanceof(Error);
+        err.code.should.equal('ENOENT');
+      }
+    }).then(null, function (err) {
+      debuglog(err);
+      assert.notOk(err, 'no error should ever be returned');
+    });
+  });
+
+  it('backup success', function () {
+    return initOrRename(myVault, 'prev-keys.json', 'keys.json').then(function () {
+      return internal.backup(myVault).then(function () {
+        try {
+          var stats = fs.statSync(BACKUP_FILE);
+          debuglog(stats);
+          debuglog(stats.isFile());
+          stats.isFile().should.be.true;
+        } catch (err) {
+          debuglog(err);
+          assert.notOk(err, 'backup file failed for some reason');
+        }
+      }).then(null, function (err) {
+        debuglog(err);
+        assert.notOk(err, 'no error should ever be returned');
+      });
+    }).then(null, function (err) {
+      debuglog(err);
+      assert.notOk(err, 'failed to init vault');
+    });
+  });
+
+  it('recover - no file', function () {
+    renameFile('keys.json', 'prev-keys.json');
+    myVault.token = null;
+    myVault.keys = [];
+    return internal.recover(myVault).then(function () {
+      expect(myVault.token).to.be.null;
+      expect(myVault.keys).to.be.empty;
+    });
+  });
+
+  it('recover - invalid file data', function () {
+    var data = '{"root"}';
+    fs.writeFileSync(BACKUP_FILE, data);
+    return internal.recover(myVault).then(function () {
+      expect(myVault.token).to.be.null;
+      expect(myVault.keys).to.be.empty;
+    });
+  });
+
+  it('recover - no root token', function () {
+    var data = JSON.stringify({
+      "keys": []
+    });
+    fs.writeFileSync(BACKUP_FILE, data);
+    return internal.recover(myVault).then(function () {
+      expect(myVault.token).to.be.null;
+      expect(myVault.keys).to.be.empty;
+    });
+  });
+
+  it('recover - keys not Array', function () {
+    var data = JSON.stringify({
+      "root": "xyz",
+      "keys": "abc,xyz"
+    });
+    fs.writeFileSync(BACKUP_FILE, data);
+    return internal.recover(myVault).then(function () {
+      expect(myVault.token).to.be.null;
+      expect(myVault.keys).to.be.empty;
+    });
+  });
+
+  it('recover - keys empty Array', function () {
+    var data = JSON.stringify({
+      "root": "xyz",
+      "keys": []
+    });
+    fs.writeFileSync(BACKUP_FILE, data);
+    return internal.recover(myVault).then(function () {
+      expect(myVault.token).to.be.null;
+      expect(myVault.keys).to.be.empty;
+    });
+  });
+
+  it('recover - success', function () {
+    fs.unlinkSync(BACKUP_FILE);
+    renameFile('prev-keys.json', 'keys.json');
+    return internal.recover(myVault).then(function () {
+      expect(myVault.token).to.not.be.null;
+      expect(myVault.keys).to.not.be.empty;
+    });
+  });
+
+  after(function () {
+    return myVault.deleteMount({
+      id: 'consul'
+    }).then(function () {
+      if (!myVault.status.sealed) {
+        return myVault.seal().then(function () {
+          debuglog('vault sealed: %s', myVault.status.sealed);
+        }).then(null, function (err) {
+          debuglog(err);
+          debuglog('failed to seal vault: %s', err.message);
+        });
+      }
+    }).then(null, function (err) {
+      debuglog(err);
+      debuglog('failed to remove consul mount: %s', err.message);
+    });
+  });
+});

--- a/tests/mounts.js
+++ b/tests/mounts.js
@@ -1,0 +1,320 @@
+require('./helpers.js').should;
+
+var
+  helpers = require('./helpers'),
+  debuglog = require('util').debuglog('vaulted-tests'),
+  _ = require('lodash'),
+  chai = helpers.chai,
+  assert = helpers.assert,
+  Vault = require('../lib/vaulted');
+
+chai.use(helpers.cap);
+
+var VAULT_HOST = helpers.VAULT_HOST;
+var VAULT_PORT = helpers.VAULT_PORT;
+
+
+describe('mounts', function () {
+  var myVault;
+
+  before(function () {
+    myVault = new Vault({
+      // debug: 1,
+      vault_host: VAULT_HOST,
+      vault_port: VAULT_PORT,
+      vault_ssl: 0
+    });
+
+    return myVault.prepare().bind(myVault)
+    .then(myVault.init)
+    .then(myVault.unSeal)
+    .catch(function onError(err) {
+      debuglog('(before) vault setup failed: %s', err.message);
+    });
+
+  });
+
+  describe('#getMounts', function () {
+
+    it('should reject with an Error if not initialized or unsealed', function () {
+      var newVault = new Vault({});
+      return newVault.getMounts().should.be.rejectedWith(/Vault has not been initialized/);
+    });
+
+    it('should update internal state with list of mounts', function () {
+      var existingMounts = myVault.mounts;
+      return myVault.getMounts().then(function (mounts) {
+        existingMounts.should.be.empty;
+        mounts.should.not.be.empty;
+        existingMounts.should.not.contain.keys('sys/');
+        mounts.should.contain.keys('sys/');
+      });
+    });
+
+  });
+
+  describe('#createMount', function () {
+
+    it('should reject with an Error if not initialized or unsealed', function () {
+      var newVault = new Vault({});
+      return newVault.createMount({
+        id: 'other',
+        body: {
+          type: 'consul'
+        }
+      }).should.be.rejectedWith(/Vault has not been initialized/);
+    });
+
+    it('should reject with an Error if no options provided', function () {
+      return myVault.createMount().then(function (mounts) {
+        debuglog('createMount successful (should fail)', mounts);
+        assert.notOk(mounts, 'no mount details successfully created!');
+      }).then(null, function (err) {
+        debuglog(err);
+        err.should.be.an.instanceof(Error);
+        err.message.should.equal('You must provide mount id.');
+      });
+    });
+
+    it('should reject with an Error if option id empty', function () {
+      return myVault.createMount({
+        id: ''
+      }).then(function (mounts) {
+        debuglog('createMount successful (should fail)', mounts);
+        assert.notOk(mounts, 'no mount id successfully created!');
+      }).then(null, function (err) {
+        debuglog(err);
+        err.should.be.an.instanceof(Error);
+        err.message.should.equal('You must provide mount id.');
+      });
+    });
+
+    it('should reject with an Error if option body empty', function () {
+      return myVault.createMount({
+        id: 'xzy',
+        body: null
+      }).then(function (mounts) {
+        debuglog('createMount successful (should fail)', mounts);
+        assert.notOk(mounts, 'no mount body successfully created!');
+      }).then(null, function (err) {
+        debuglog(err);
+        err.should.be.an.instanceof(Error);
+        err.message.should.equal('You must provide mount details.');
+      });
+    });
+
+    it('should reject with an Error if option body without type', function () {
+      return myVault.createMount({
+        id: 'xzy',
+        body: {}
+      }).then(function (mounts) {
+        debuglog('createMount successful (should fail)', mounts);
+        assert.notOk(mounts, 'no mount body successfully created!');
+      }).then(null, function (err) {
+        debuglog(err);
+        err.should.be.an.instanceof(Error);
+        err.message.should.equal('You must provide mount type.');
+      });
+    });
+
+    it('should reject with an Error if option body with empty type', function () {
+      return myVault.createMount({
+        id: 'xzy',
+        body: {
+          type: ''
+        }
+      }).then(function (mounts) {
+        debuglog('createMount successful (should fail)', mounts);
+        assert.notOk(mounts, 'no mount body type successfully created!');
+      }).then(null, function (err) {
+        debuglog(err);
+        err.should.be.an.instanceof(Error);
+        err.message.should.equal('You must provide mount type.');
+      });
+    });
+
+    it('should resolve to updated list of mounts', function () {
+      var existingMounts = _.cloneDeep(myVault.mounts);
+      return myVault.createMount({
+        id: 'other',
+        body: {
+          type: 'consul'
+        }
+      }).then(function (mounts) {
+        existingMounts.should.not.be.empty;
+        mounts.should.not.be.empty;
+        existingMounts.should.not.contain.keys('other/');
+        mounts.should.contain.keys('other/');
+      });
+    });
+
+  });
+
+  describe('#reMount', function () {
+
+    it('should reject no options provided', function () {
+      return myVault.reMount().then(function (mounts) {
+        debuglog('reMount successful (should fail)', mounts);
+        assert.notOk(mounts, 'no mount details successfully created!');
+      }).then(null, function (err) {
+        debuglog(err);
+        err.should.be.an.instanceof(Error);
+        err.message.should.equal('You must provide from mount.');
+      });
+    });
+
+    it('should reject empty option from', function () {
+      return myVault.reMount({
+        from: ''
+      }).then(function (mounts) {
+        debuglog('reMount successful (should fail)', mounts);
+        assert.notOk(mounts, 'no mount details successfully created!');
+      }).then(null, function (err) {
+        debuglog(err);
+        err.should.be.an.instanceof(Error);
+        err.message.should.equal('You must provide from mount.');
+      });
+    });
+
+    it('should reject no option to', function () {
+      return myVault.reMount({
+        from: 'xyz'
+      }).then(function (mounts) {
+        debuglog('reMount successful (should fail)', mounts);
+        assert.notOk(mounts, 'no mount details successfully created!');
+      }).then(null, function (err) {
+        debuglog(err);
+        err.should.be.an.instanceof(Error);
+        err.message.should.equal('You must provide to mount.');
+      });
+    });
+
+    it('should reject empty option to', function () {
+      return myVault.reMount({
+        from: 'xyz',
+        to: ''
+      }).then(function (mounts) {
+        debuglog('reMount successful (should fail)', mounts);
+        assert.notOk(mounts, 'no mount details successfully created!');
+      }).then(null, function (err) {
+        debuglog(err);
+        err.should.be.an.instanceof(Error);
+        err.message.should.equal('You must provide to mount.');
+      });
+    });
+
+    it('should reject no existing from mount', function () {
+      return myVault.reMount({
+        from: 'xyz',
+        to: 'abc'
+      }).then(function (mounts) {
+        debuglog('reMount successful (should fail)', mounts);
+        assert.notOk(mounts, 'no mount details successfully created!');
+      }).then(null, function (err) {
+        debuglog(err);
+        err.should.be.an.instanceof(Error);
+        err.message.should.equal('Could not find existing mount named: xyz');
+      });
+    });
+
+    it('should reject with an Error if not initialized or unsealed', function () {
+      var newVault = new Vault({});
+      newVault.mounts = _.cloneDeep(myVault.mounts);
+      return newVault.reMount({
+        from: 'other',
+        to: 'sample'
+      }).should.be.rejectedWith(/Vault has not been initialized/);
+    });
+
+    it('should resolve to updated list of mounts (when slash provided)', function () {
+      var existingMounts = _.cloneDeep(myVault.mounts);
+      return myVault.reMount({
+        from: 'other/',
+        to: 'samplex'
+      }).then(function (mounts) {
+        existingMounts.should.not.be.empty;
+        mounts.should.not.be.empty;
+        existingMounts.should.contain.keys('other/');
+        existingMounts.should.not.contain.keys('samplex/');
+        mounts.should.not.contain.keys('other/');
+        mounts.should.contain.keys('samplex/');
+      });
+    });
+
+    it('should resolve to updated list of mounts', function () {
+      var existingMounts = _.cloneDeep(myVault.mounts);
+      return myVault.reMount({
+        from: 'samplex',
+        to: 'sample'
+      }).then(function (mounts) {
+        existingMounts.should.not.be.empty;
+        mounts.should.not.be.empty;
+        existingMounts.should.contain.keys('samplex/');
+        existingMounts.should.not.contain.keys('sample/');
+        mounts.should.not.contain.keys('samplex/');
+        mounts.should.contain.keys('sample/');
+      });
+    });
+
+  });
+
+  describe('#deleteMount', function () {
+
+    it('should reject with an Error if not initialized or unsealed', function () {
+      var newVault = new Vault({});
+      return newVault.deleteMount({
+        id: 'sample'
+      }).should.be.rejectedWith(/Vault has not been initialized/);
+    });
+
+    it('should reject if no options provided', function () {
+      return myVault.deleteMount().then(function (self) {
+        debuglog('deleteMount successful (should fail)', self);
+        assert.notOk(self, 'no mount details successfully created!');
+      }).then(null, function (err) {
+        debuglog(err);
+        err.should.be.an.instanceof(Error);
+        err.message.should.equal('You must provide mount id.');
+      });
+    });
+
+    it('should reject if no option id provided', function () {
+      return myVault.deleteMount({
+        id: ''
+      }).then(function (self) {
+        debuglog('deleteMount successful (should fail)', self);
+        assert.notOk(self, 'no mount details successfully created!');
+      }).then(null, function (err) {
+        debuglog(err);
+        err.should.be.an.instanceof(Error);
+        err.message.should.equal('You must provide mount id.');
+      });
+    });
+
+    it('should resolve to updated instance with mount removed', function () {
+      var existingMounts = _.cloneDeep(myVault.mounts);
+      return myVault.deleteMount({
+        id: 'sample'
+      }).then(function (mounts) {
+        existingMounts.should.not.be.empty;
+        mounts.should.not.be.empty;
+        existingMounts.should.contain.keys('sample/');
+        mounts.should.not.contain.keys('sample/');
+        mounts.should.contain.keys('sys/');
+      });
+    });
+
+  });
+
+  after(function () {
+    if (!myVault.status.sealed) {
+      return myVault.seal().then(function () {
+        debuglog('vault sealed: %s', myVault.status.sealed);
+      }).then(null, function (err) {
+        debuglog(err);
+        debuglog('failed to seal vault: %s', err.message);
+      });
+    }
+  });
+
+});

--- a/tests/seal.js
+++ b/tests/seal.js
@@ -1,0 +1,108 @@
+require('./helpers.js').should;
+
+var
+  helpers = require('./helpers'),
+  debuglog = require('util').debuglog('vaulted-tests'),
+  _ = require('lodash'),
+  chai = helpers.chai,
+  assert = helpers.assert,
+  expect = helpers.expect,
+  Vault = require('../lib/vaulted');
+
+chai.use(helpers.cap);
+
+var VAULT_HOST = helpers.VAULT_HOST;
+var VAULT_PORT = helpers.VAULT_PORT;
+
+
+describe('seal', function () {
+  var myVault;
+
+  before(function () {
+    myVault = new Vault({
+      // debug: 1,
+      vault_host: VAULT_HOST,
+      vault_port: VAULT_PORT,
+      vault_ssl: 0
+    });
+
+    return myVault.prepare();
+  });
+
+  describe('#getSealedStatus', function () {
+
+    it('should resolve to binded instance - success', function () {
+      return myVault.getSealedStatus().then(function (self) {
+        self.status.should.have.property('sealed');
+        self.status.sealed.should.be.true;
+      });
+    });
+
+  });
+
+  describe('#unSeal', function () {
+
+    it('should resolve to binded instance - success', function () {
+      return myVault.unSeal().then(function (self) {
+        self.status.should.have.property('sealed');
+        self.status.sealed.should.be.false;
+      });
+    });
+
+    it('should resolve to binded instance - already unsealed', function () {
+      return myVault.unSeal().then(function (self) {
+        self.status.should.have.property('sealed');
+        self.status.sealed.should.be.false;
+      });
+    });
+
+    it('should be rejected with Error - not initialized', function () {
+      myVault.initialized = false;
+      return myVault.unSeal().should.be.rejectedWith(/Vault has not been initialized/);
+    });
+
+  });
+
+  describe('#seal', function () {
+
+    it('should be rejected with Error - not initialized', function () {
+      myVault.initialized = false;
+      return myVault.seal().should.be.rejectedWith(/Vault has not been initialized/);
+    });
+
+    it('should resolve to binded instance - success', function () {
+      var existing = _.cloneDeep(myVault.status);
+      myVault.initialized = true;
+      return myVault.seal().then(function (self) {
+        existing.should.have.property('sealed');
+        existing.sealed.should.be.false;
+        self.status.should.have.property('sealed');
+        self.status.sealed.should.be.true;
+      });
+    });
+
+    it('should resolve to binded instance - already sealed', function () {
+      var existing = _.cloneDeep(myVault.status);
+      myVault.initialized = true;
+      return myVault.seal().then(function (self) {
+        existing.should.have.property('sealed');
+        existing.sealed.should.be.true;
+        self.status.should.have.property('sealed');
+        self.status.sealed.should.be.true;
+      });
+    });
+
+  });
+
+  after(function () {
+    if (!myVault.status.sealed) {
+      return myVault.seal().then(function () {
+        debuglog('vault sealed: %s', myVault.status.sealed);
+      }).then(null, function (err) {
+        debuglog(err);
+        debuglog('failed to seal vault: %s', err.message);
+      });
+    }
+  });
+
+});

--- a/tests/secret.js
+++ b/tests/secret.js
@@ -1,16 +1,17 @@
 require('./helpers.js').should;
 
 var
+  helpers = require('./helpers'),
   debuglog = require('util').debuglog('vaulted-tests'),
-  chai = require('./helpers').chai,
-  // assert = require('./helpers').assert,
+  chai = helpers.chai,
+  assert = helpers.assert,
+  expect = helpers.expect,
   Vault = require('../lib/vaulted');
 
-chai.use(require('./helpers').cap);
+var VAULT_HOST = helpers.VAULT_HOST;
+var VAULT_PORT = helpers.VAULT_PORT;
 
-// if running within container the HOME is fixed; else running locally so assume
-// that consul and vault are also running locally.
-var VAULT_HOST = process.env.HOME === '/home/appy' ? 'vault' : '127.0.0.1';
+chai.use(helpers.cap);
 
 
 describe('secret', function () {
@@ -20,36 +21,64 @@ describe('secret', function () {
     myVault = new Vault({
       // debug: 1,
       vault_host: VAULT_HOST,
-      vault_port: 8200,
+      vault_port: VAULT_PORT,
       vault_ssl: 0
     });
 
-    return myVault.init().then(function () {
-      return myVault.unSeal().then(null, function (err) {
-        debuglog('failed to unSeal Vault: %s', err.message);
-      });
-    }).then(null, function (err) {
-      debuglog('failed to init Vault: %s', err.message);
-      return myVault.unSeal().then(null, function (err) {
-        debuglog('failed to unSeal Vault: %s', err.message);
-      });
+    return myVault.prepare().bind(myVault)
+    .then(myVault.init)
+    .then(myVault.unSeal)
+    .catch(function onError(err) {
+      debuglog('(before) vault setup failed: %s', err.message);
     });
-    // to be version
-    // return myVault.prepare().then(function () {
-    //   return myVault.init().then(function () {
-    //     return myVault.unSeal();
-    //   });
-    // }).then(null, function (err) {
-    //   debuglog('(before) vault setup failed: %s', err.message);
-    // });
   });
 
   describe('#write', function () {
 
-    it('no secret provided', function () {
-      return myVault.write({}).then(function () {
+    it('should reject with an Error if not initialized or unsealed', function () {
+      var newVault = new Vault({});
+      return newVault.write({
+        id: 'sample',
+        body: {
+          value: 'dummy'
+        }
+      }).should.be.rejectedWith(/Vault has not been initialized/);
+    });
+
+    it('no secret id provided', function () {
+      return myVault.write().then(function () {
         debuglog('write secret successful (should fail)');
-        // assert.notOk(true, 'no secret body successfully created!');
+        assert.notOk(true, 'no secret id successfully created!');
+      }).then(null, function (err) {
+        err.should.be.an.instanceof(Error);
+        err.message.should.equal('You must provide secret id.');
+      });
+    });
+
+    it('empty secret id provided', function () {
+      return myVault.write({id: ''}).then(function () {
+        debuglog('write secret successful (should fail)');
+        assert.notOk(true, 'no secret id successfully created!');
+      }).then(null, function (err) {
+        err.should.be.an.instanceof(Error);
+        err.message.should.equal('You must provide secret id.');
+      });
+    });
+
+    it('no secret provided', function () {
+      return myVault.write({id: 'dummy'}).then(function () {
+        debuglog('write secret successful (should fail)');
+        assert.notOk(true, 'no secret body successfully created!');
+      }).then(null, function (err) {
+        err.should.be.an.instanceof(Error);
+        err.message.should.equal('You must provide an secret to write to the Vault.');
+      });
+    });
+
+    it('empty secret provided', function () {
+      return myVault.write({id: 'dummy', body: null}).then(function () {
+        debuglog('write secret successful (should fail)');
+        assert.notOk(true, 'no secret body successfully created!');
       }).then(null, function (err) {
         err.should.be.an.instanceof(Error);
         err.message.should.equal('You must provide an secret to write to the Vault.');
@@ -69,12 +98,41 @@ describe('secret', function () {
 
   describe('#read', function () {
 
+    it('should reject with an Error if not initialized or unsealed', function () {
+      var newVault = new Vault({});
+      return newVault.read({
+        id: 'sample'
+      }).should.be.rejectedWith(/Vault has not been initialized/);
+    });
+
+    it('no secret id provided', function () {
+      return myVault.read().then(function (secret) {
+        debuglog('secret: %s', secret);
+        assert.notOk(secret, 'get secret successful!');
+      }).then(null, function (err) {
+        err.should.be.an.instanceof(Error);
+        err.message.should.equal('You must provide secret id.');
+      });
+    });
+
+    it('empty secret id provided', function () {
+      return myVault.read({
+        id: ''
+      }).then(function (secret) {
+        debuglog('secret: %s', secret);
+        assert.notOk(secret, 'get secret successful!');
+      }).then(null, function (err) {
+        err.should.be.an.instanceof(Error);
+        err.message.should.equal('You must provide secret id.');
+      });
+    });
+
     it('secret not found', function () {
       return myVault.read({
         id: 'fake'
       }).then(function (secret) {
         debuglog('secret: %s', secret);
-        // assert.notOk(secret, 'get secret successful!');
+        assert.notOk(secret, 'get secret successful!');
       }).then(null, function (err) {
         err.should.be.an.instanceof(Error);
         err.should.have.property('statusCode');
@@ -90,7 +148,7 @@ describe('secret', function () {
         secret.data.value.should.be.equal('dummy');
       }).then(null, function (err) {
         debuglog(err);
-        // expect(err).to.be.undefined;
+        expect(err).to.be.undefined;
       });
     });
 
@@ -98,12 +156,41 @@ describe('secret', function () {
 
   describe('#delete', function () {
 
+    it('should reject with an Error if not initialized or unsealed', function () {
+      var newVault = new Vault({});
+      return newVault.delete({
+        id: 'sample'
+      }).should.be.rejectedWith(/Vault has not been initialized/);
+    });
+
+    it('no secret id provided', function () {
+      return myVault.delete().then(function () {
+        debuglog('delete should fail but was successful');
+        assert.notOk(true, 'delete secret successful!');
+      }).then(null, function (err) {
+        err.should.be.an.instanceof(Error);
+        err.message.should.equal('You must provide secret id.');
+      });
+    });
+
+    it('empty secret id provided', function () {
+      return myVault.delete({
+        id: ''
+      }).then(function () {
+        debuglog('delete should fail but was successful');
+        assert.notOk(true, 'delete secret successful!');
+      }).then(null, function (err) {
+        err.should.be.an.instanceof(Error);
+        err.message.should.equal('You must provide secret id.');
+      });
+    });
+
     it.skip('secret not deleted', function () {
       return myVault.delete({
         id: 'fake'
       }).then(function () {
         debuglog('delete should fail but was successful');
-        // assert.notOk(true, 'delete secret successful!');
+        assert.notOk(true, 'delete secret successful!');
       }).then(null, function (err) {
         debuglog(err);
         err.should.be.an.instanceof(Error);
@@ -120,14 +207,12 @@ describe('secret', function () {
 
   after(function () {
     if (!myVault.status.sealed) {
-      debuglog('should seal vault but unable to right now');
-      // requires bugfix on the seal method to operate
-      // return myVault.seal().then(function () {
-      //   debuglog('vault sealed: %s', myVault.status.sealed);
-      // }).then(null, function (err) {
-      //   debuglog(err);
-      //   debuglog('failed to seal vault: %s', err.message);
-      // });
+      return myVault.seal().then(function () {
+        debuglog('vault sealed: %s', myVault.status.sealed);
+      }).then(null, function (err) {
+        debuglog(err);
+        debuglog('failed to seal vault: %s', err.message);
+      });
     }
   });
 


### PR DESCRIPTION
Implement test cases for the core library and documentation of each
of the public methods.

As a result of adding test cases for all modules, all API methods
will now return a promise that will be resolved or rejected. And
several bug fixes or inconsistencies were resolved.

The init method was made more user-friendly such that if the Vault
has already been initialized the Vault is returned instead of rejecting
the request.

Because the internal state of the Vault of critical and the ability to
repeatedly restart the Vault is required, internal state management has
been made to be recoverable.

closes #9 
