### PR TITLE
chore(api): Add Health and Leader

### DIFF
--- a/lib/health.js
+++ b/lib/health.js
@@ -1,0 +1,24 @@
+var
+  Vaulted = {},
+  Promise = require('bluebird'),
+  _ = require('lodash');
+
+module.exports = function extend(Proto) {
+  _.extend(Proto, Vaulted);
+};
+
+/**
+ * Gets the health of the vault
+ *
+ * @return {Promise<Object>} Promise which is resolved with the vault health.
+ */
+Vaulted.checkHealth = Promise.method(function checkHealth(options) {
+  options = options || {};
+  if (!_.isBoolean(options.standbyok)) {
+    options.standbyok = false;
+  }
+  return this.api.getEndpoint('sys/health')
+    .get({
+      qs: options
+    });
+});

--- a/lib/leader.js
+++ b/lib/leader.js
@@ -1,0 +1,21 @@
+var
+  Vaulted = {},
+  Promise = require('bluebird'),
+  _ = require('lodash');
+
+module.exports = function extend(Proto) {
+  Vaulted.getLeaderEndpoint = _.partial(Proto.validateEndpoint, 'sys/leader');
+  _.extend(Proto, Vaulted);
+};
+
+/**
+ * Gets the leader of a vault
+ *
+ * @return {Promise<Object>} Promise which is resolved with the vault leader.
+ */
+Vaulted.getLeader = Promise.method(function getLeader() {
+  return this.getLeaderEndpoint()
+    .get({
+      headers: this.headers
+    });
+});

--- a/lib/vaulted.js
+++ b/lib/vaulted.js
@@ -106,3 +106,5 @@ require('./seal')(Vaulted.prototype);
 require('./init')(Vaulted.prototype);
 require('./secret')(Vaulted.prototype);
 require('./mounts')(Vaulted.prototype);
+require('./health')(Vaulted.prototype);
+require('./leader')(Vaulted.prototype);

--- a/tests/health.js
+++ b/tests/health.js
@@ -1,0 +1,123 @@
+require('./helpers.js').should;
+
+var
+  helpers = require('./helpers'),
+  debuglog = require('util').debuglog('vaulted-tests'),
+  chai = helpers.chai,
+  assert = helpers.assert,
+  Vault = require('../lib/vaulted.js');
+
+chai.use(helpers.cap);
+
+var VAULT_HOST = helpers.VAULT_HOST;
+var VAULT_PORT = helpers.VAULT_PORT;
+
+describe('health', function() {
+  var myVault = null;
+
+  before(function() {
+    myVault = new Vault({
+      vault_host: VAULT_HOST,
+      vault_port: VAULT_PORT,
+      vault_ssl: 0
+    });
+    return myVault.prepare();
+  });
+
+  it('should reject with Error and statusCode 500 when not initialized or sealed', function () {
+    return myVault.checkHealth().then(function (status) {
+      debuglog('health status: ', status);
+      assert.notOk(status, 'health status should not be returned');
+    }).catch(function (err) {
+      debuglog(err);
+      err.should.have.property('statusCode');
+      err.statusCode.should.equal(500);
+      err.should.have.property('error');
+      err.error.should.have.property('initialized');
+      // could be true or false depending what tests get executed before this one
+      // so to make sure it is consistent this line is being commented out.
+      // there is no way to "uninitialize" a vault.
+      // err.error.initialized.should.be.true;
+      err.error.should.have.property('sealed');
+      err.error.sealed.should.be.true;
+      err.error.should.have.property('standby');
+    });
+  });
+
+  describe('#unsealed vault tests', function () {
+
+    beforeEach(function () {
+      return myVault.init().bind(myVault).then(myVault.unSeal).catch(function (err) {
+        debuglog('failed to initialize and unseal vault: %s', err.error || err.message);
+      });
+    });
+
+    // need a standby instance to properly test
+    it.skip('should reject with Error and statusCode 429 when unsealed and standby (standbyok false)', function () {
+      return myVault.checkHealth().then(function (status) {
+        debuglog('health status: ', status);
+        assert.ok(status, 'status should be defined');
+        status.should.have.property('initialized');
+        status.initialized.should.be.true;
+        status.should.have.property('sealed');
+        status.sealed.should.be.false;
+        status.should.have.property('standby');
+        status.standby.should.be.true;
+      });
+      // .catch(function (err) {
+      //   debuglog(err);
+      //   assert.notOk(err, 'should be successful and not have failed');
+      //   err.should.be.an.instanceof(Error);
+      //   err.should.have.property('statusCode');
+      //   err.statusCode.should.equal(429);
+      //   err.should.have.property('error');
+      //   err.error.should.have.property('initialized');
+      //   err.error.initialized.should.be.true;
+      //   err.error.should.have.property('sealed');
+      //   err.error.sealed.should.be.false;
+      //   err.error.should.have.property('standby');
+      //   err.error.standby.should.be.true;
+      // });
+
+    });
+
+    it('should resolve with health details if initialized and unsealed and active', function () {
+      return myVault.checkHealth().then(function (status) {
+        debuglog('health status: ', status);
+        assert.ok(status, 'status should be defined');
+        status.should.have.property('initialized');
+        status.initialized.should.be.true;
+        status.should.have.property('sealed');
+        status.sealed.should.be.false;
+        status.should.have.property('standby');
+        status.standby.should.be.false;
+      });
+    });
+
+    it('should resolve with health details if initialized and unsealed and standbyok true', function () {
+      return myVault.checkHealth({standbyok: true}).then(function (status) {
+        debuglog('health status: ', status);
+        assert.ok(status, 'status should be defined');
+        status.should.have.property('initialized');
+        status.initialized.should.be.true;
+        status.should.have.property('sealed');
+        status.sealed.should.be.false;
+        status.should.have.property('standby');
+        status.standby.should.be.false;
+      });
+    });
+
+  });
+
+  after(function () {
+    if (!myVault.status.sealed) {
+      return myVault.seal().then(function () {
+        debuglog('vault sealed: %s', myVault.status.sealed);
+      }).then(null, function (err) {
+        debuglog(err);
+        debuglog('failed to seal vault: %s', err.message);
+      });
+    }
+  });
+
+});

--- a/tests/leader.js
+++ b/tests/leader.js
@@ -1,0 +1,60 @@
+require('./helpers.js').should;
+
+var
+  helpers = require('./helpers'),
+  debuglog = require('util').debuglog('vaulted-tests'),
+  chai = helpers.chai,
+  expect = helpers.expect
+  Vault = require('../lib/vaulted');
+
+chai.use(helpers.cap);
+
+var VAULT_HOST = helpers.VAULT_HOST;
+var VAULT_PORT = helpers.VAULT_PORT;
+
+
+describe('leader', function () {
+  var myVault;
+
+  before(function () {
+    myVault = new Vault({
+      // debug: 1,
+      vault_host: VAULT_HOST,
+      vault_port: VAULT_PORT,
+      vault_ssl: 0
+    });
+
+    return myVault.prepare().bind(myVault)
+    .then(myVault.init)
+    .then(myVault.unSeal)
+    .catch(function onError(err) {
+      debuglog('(before) vault setup failed: %s', err.message);
+    });
+
+  });
+
+  it('should resolve with leader information', function () {
+    return myVault.getLeader().then(function (leader) {
+      debuglog('leader: ', leader);
+      expect(leader).to.not.be.undefined;
+      leader.should.have.property('ha_enabled');
+      leader.ha_enabled.should.be.exist;
+      leader.should.have.property('is_self');
+      leader.is_self.should.be.exist;
+      leader.should.have.property('leader_address');
+      leader.leader_address.should.be.exist;
+    });
+  });
+
+  after(function () {
+    if (!myVault.status.sealed) {
+      return myVault.seal().then(function () {
+        debuglog('vault sealed: %s', myVault.status.sealed);
+      }).then(null, function (err) {
+        debuglog(err);
+        debuglog('failed to seal vault: %s', err.message);
+      });
+    }
+  });
+
+});


### PR DESCRIPTION
- `sys/leader`: Provides the capability to determine if the Vault
  is HA enabled, if the vault being communicated with is the leader,
  and what the address is for the leader.
- `sys/health`: Provides the capability to retrieve the health status
  of the vault.

closes #15
closes #21
