### PR TITLE
chore(project): Refactor test cases and general cleanup

### DIFF
--- a/config/api_sys.json
+++ b/config/api_sys.json
@@ -225,7 +225,7 @@
             ]
         },
         {
-            "name": "sys/renew",
+            "name": "sys/renew/:id",
             "verbs": [
                 {
                     "PUT": {
@@ -242,7 +242,7 @@
             ]
         },
         {
-            "name": "sys/revoke",
+            "name": "sys/revoke/:id",
             "verbs": [
                 {
                     "PUT": {
@@ -253,7 +253,7 @@
             ]
         },
         {
-            "name": "sys/revoke-prefix",
+            "name": "sys/revoke-prefix/:id",
             "verbs": [
                 {
                     "PUT": {

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,6 +1,7 @@
 var
   _ = require('lodash'),
   fs = require('fs'),
+  path = require('path'),
   Endpoint;
 
 module.exports = API;
@@ -19,28 +20,28 @@ function API(config) {
   _.extend(this, this._loadAPIDefinitions(config));
 }
 
-API.prototype._readConfigFromPath = function _readConfigFromPath(config, api, path) {
+API.prototype._readConfigFromPath = function _readConfigFromPath(config, api, apidef) {
   var
     prefix = config.get('prefix'),
+    filename = path.basename(apidef),
     api_type,
     partial,
     parsed_api;
 
   try {
-    api_type = path.split('_')[1].split('.')[0];
-    path =  __dirname + '/../' + path;
+    api_type = filename.split('_')[1].split('.')[0];
   } catch (ex) {
-    throw new Error('Invalid file name at: ' + path + ' must be in the form: "api_<name>.json"');
+    throw new Error('Invalid file name at: ' + filename + ' must be in the form: "api_<name>.json"');
   }
 
   try {
-    parsed_api = JSON.parse(fs.readFileSync(path));
+    parsed_api = JSON.parse(fs.readFileSync(apidef));
   } catch (ex) {
-    throw new Error('Could not read API definition file at: ' + path + ' ' + ex.message);
+    throw new Error('Could not read API definition file at: ' + filename + ' ' + ex.message);
   }
 
   if (_.isUndefined(parsed_api[prefix])) {
-    throw new Error('Could not find API definition at: ' + path + ' for prefix: ' + prefix);
+    throw new Error('Could not find API definition at: ' + filename + ' for prefix: ' + prefix);
   }
 
   partial = _.partial(Endpoint.create, config.get('vault_url'));

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,9 +4,9 @@ var
   os = require('os'),
   path = require('path');
 
-module.exports = config;
+var CONFIG_DIR = path.normalize(path.join(__dirname, '..', 'config'));
 
-function config(config_obj) {
+module.exports = function config(config_obj) {
   config_obj = _.isObject(config_obj) ? config_obj : {};
   var
     conf,
@@ -70,10 +70,10 @@ function config(config_obj) {
       doc: 'API definition JSON files',
       format: Array,
       default: [
-        'config/api_sys.json',
-        'config/api_aws.json',
-        'config/api_auth.json',
-        'config/api_secret.json'
+        path.join(CONFIG_DIR, 'api_sys.json'),
+        path.join(CONFIG_DIR, 'api_aws.json'),
+        path.join(CONFIG_DIR, 'api_auth.json'),
+        path.join(CONFIG_DIR, 'api_secret.json')
       ]
     },
     backup_dir: {
@@ -97,5 +97,4 @@ function config(config_obj) {
   conf.set('vault_url', vault_url);
 
   return conf;
-}
-
+};

--- a/lib/policy.js
+++ b/lib/policy.js
@@ -42,12 +42,9 @@ Vaulted.createPolicy = Promise.method(function createPolicy(options) {
   if (_.isUndefined(options.body) || !options.body) {
     return Promise.reject(new Error('You must provide policy details.'));
   }
-  if (!_.isString(options.body.rule) || options.body.rule.length === 0) {
+  if (!_.isString(options.body.rules) || options.body.rules.length === 0) {
     return Promise.reject(new Error('You must provide policy rule as string.'));
   }
-  // According to documentation the policy must be base64 encoded; easier to handle this
-  // here vs. each user having to do this manually.
-  options.body.rule = new Buffer(options.body.rule).toString('base64');
 
   return this.getPolicyEndpoint()
     .put({

--- a/lib/vaulted.js
+++ b/lib/vaulted.js
@@ -1,8 +1,8 @@
 var
   _ = require('lodash'),
-  create_config = require('./config.js'),
+  create_config = require('./config'),
   internal = require('./internal'),
-  API = require('./api.js');
+  API = require('./api');
 
 module.exports = Vaulted;
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "npm rebuild && node index.js",
-    "test": "mocha -R spec tests/**/*.js",
-    "coverage": "istanbul cover _mocha tests/**/*.js",
+    "test": "mocha -R spec tests/**",
+    "coverage": "istanbul cover _mocha -- tests/**",
     "test-watch": "mocha --growl -R spec -w tests/**/*.js"
   },
   "keywords": [

--- a/tests/api.js
+++ b/tests/api.js
@@ -1,11 +1,15 @@
-require('./helpers.js').should;
+require('./helpers').should;
 
 var
-  chai = require('./helpers').chai,
-  config = require('../lib/config.js')(),
-  API = require('../lib/api.js');
+  path = require('path'),
+  helpers = require('./helpers'),
+  chai = helpers.chai,
+  config = require('../lib/config')(),
+  API = require('../lib/api');
 
-chai.use(require('./helpers').cap);
+chai.use(helpers.cap);
+var CONFIG_DIR = path.normalize(path.join(__dirname, 'configs'));
+
 
 describe('API', function() {
 
@@ -71,7 +75,7 @@ describe('API', function() {
 
   describe('#_readConfigFromPath', function() {
     var
-      config = require('../lib/config.js')(),
+      config = require('../lib/config')(),
       o_prefix;
 
     beforeEach(function () {
@@ -80,20 +84,20 @@ describe('API', function() {
 
     it('should throw exception if the api definition file is missing', function () {
       (function() {
-        var bad_path = 'config/asdfasdf.json';
+        var bad_path = path.join(CONFIG_DIR, 'asdfasdf.json');
         API.prototype._readConfigFromPath.call(null, config, {}, bad_path);
       }).should.throw(/Invalid file name at/);
     });
 
     it('should throw exception if the api definition file contains invalid JSON', function () {
       (function() {
-        var bad_path = 'tests/configs/bad_json.json';
+        var bad_path = path.join(CONFIG_DIR, 'bad_json.json');
         API.prototype._readConfigFromPath.call(null, config, {}, bad_path);
       }).should.throw(/Could not read API definition file/);
     });
 
     it('should load a well formed JSON doc with the correct filename', function () {
-        var good_path = 'config/api_auth.json';
+        var good_path = path.normalize(path.join(__dirname, '..', 'config', 'api_auth.json'));
         var result = API.prototype._readConfigFromPath.call(null, config, {}, good_path);
         result.should.exist;
         result.should.include.keys('auth');

--- a/tests/auth/token.js
+++ b/tests/auth/token.js
@@ -1,44 +1,29 @@
-require('../helpers.js').should;
+require('../helpers').should;
 
 var
   helpers = require('../helpers'),
-  debuglog = require('util').debuglog('vaulted-tests'),
+  debuglog = helpers.debuglog,
   _ = require('lodash'),
   chai = helpers.chai,
-  assert = helpers.assert,
-  expect = helpers.expect,
-  Vault = require('../../lib/vaulted');
+  expect = helpers.expect;
 
 chai.use(helpers.cap);
 
-var VAULT_HOST = helpers.VAULT_HOST;
-var VAULT_PORT = helpers.VAULT_PORT;
-
 
 describe('auth/tokens', function () {
+  var newVault = helpers.getEmptyVault();
   var myVault;
 
   before(function () {
-    myVault = new Vault({
-      // debug: 1,
-      vault_host: VAULT_HOST,
-      vault_port: VAULT_PORT,
-      vault_ssl: 0
+    return helpers.getReadyVault().then(function (vault) {
+      myVault = vault;
     });
-
-    return myVault.prepare().bind(myVault)
-      .then(myVault.init)
-      .then(myVault.unSeal)
-      .catch(function onError(err) {
-        debuglog('(before) vault setup failed: %s', err.message);
-      });
 
   });
 
   describe('#createToken', function () {
 
     it('should reject with an Error if not initialized or unsealed', function () {
-      var newVault = new Vault({});
       return newVault.createToken().should.be.rejectedWith(/Vault has not been initialized/);
     });
 
@@ -93,7 +78,6 @@ describe('auth/tokens', function () {
     });
 
     it('should reject with an Error if not initialized or unsealed', function () {
-      var newVault = new Vault({});
       return newVault.renewToken({
         id: 'abcxyz'
       }).should.be.rejectedWith(/Vault has not been initialized/);
@@ -174,7 +158,6 @@ describe('auth/tokens', function () {
   describe('#lookupToken', function () {
 
     it('should reject with an Error if not initialized or unsealed', function () {
-      var newVault = new Vault({});
       return newVault.lookupToken({
         id: 'abcxyz'
       }).should.be.rejectedWith(/Vault has not been initialized/);
@@ -224,7 +207,6 @@ describe('auth/tokens', function () {
     });
 
     it('should reject with an Error if not initialized or unsealed', function () {
-      var newVault = new Vault({});
       return newVault.revokeToken({
         id: 'abcxyz'
       }).should.be.rejectedWith(/Vault has not been initialized/);
@@ -276,7 +258,6 @@ describe('auth/tokens', function () {
     });
 
     it('should reject with an Error if not initialized or unsealed', function () {
-      var newVault = new Vault({});
       return newVault.revokeTokenOrphan({
         id: 'abcxyz'
       }).should.be.rejectedWith(/Vault has not been initialized/);
@@ -338,7 +319,6 @@ describe('auth/tokens', function () {
     });
 
     it('should reject with an Error if not initialized or unsealed', function () {
-      var newVault = new Vault({});
       return newVault.revokeTokenPrefix({
         id: 'abcxyz'
       }).should.be.rejectedWith(/Vault has not been initialized/);
@@ -390,7 +370,6 @@ describe('auth/tokens', function () {
   describe('#lookupTokenSelf', function () {
 
     it('should reject with an Error if not initialized or unsealed', function () {
-      var newVault = new Vault({});
       return newVault.lookupTokenSelf().should.be.rejectedWith(/Vault has not been initialized/);
     });
 
@@ -426,7 +405,6 @@ describe('auth/tokens', function () {
     });
 
     it('should reject with an Error if not initialized or unsealed', function () {
-      var newVault = new Vault({});
       return newVault.revokeTokenSelf().should.be.rejectedWith(/Vault has not been initialized/);
     });
 
@@ -450,12 +428,7 @@ describe('auth/tokens', function () {
 
   after(function () {
     if (!myVault.status.sealed) {
-      return myVault.seal().then(function () {
-        debuglog('vault sealed: %s', myVault.status.sealed);
-      }).then(null, function (err) {
-        debuglog(err);
-        debuglog('failed to seal vault: %s', err.message);
-      });
+      return helpers.resealVault(myVault);
     }
   });
 

--- a/tests/endpoint.js
+++ b/tests/endpoint.js
@@ -1,17 +1,15 @@
-require('./helpers.js').should;
+require('./helpers').should;
 
 var
-  debuglog = require('util').debuglog('vaulted-tests'),
-  helpers = require('./helpers'),
-  chai = helpers.chai,
   _ = require('lodash'),
   fs = require('fs'),
-  Endpoint = require('../lib/endpoint.js')();
+  helpers = require('./helpers'),
+  debuglog = helpers.debuglog,
+  chai = helpers.chai,
+  Endpoint = require('../lib/endpoint')();
 
 chai.use(helpers.cap);
-var VAULT_HOST = helpers.VAULT_HOST;
-var VAULT_PORT = helpers.VAULT_PORT;
-var BASE_URL = 'http://' + VAULT_HOST + ':' + VAULT_PORT;
+var BASE_URL = 'http://' + helpers.VAULT_HOST + ':' + helpers.VAULT_PORT;
 
 
 describe('Endpoint', function() {

--- a/tests/health.js
+++ b/tests/health.js
@@ -1,27 +1,21 @@
-require('./helpers.js').should;
+require('./helpers').should;
 
 var
   helpers = require('./helpers'),
-  debuglog = require('util').debuglog('vaulted-tests'),
+  debuglog = helpers.debuglog,
   chai = helpers.chai,
-  assert = helpers.assert,
-  Vault = require('../lib/vaulted.js');
+  assert = helpers.assert;
 
 chai.use(helpers.cap);
 
-var VAULT_HOST = helpers.VAULT_HOST;
-var VAULT_PORT = helpers.VAULT_PORT;
 
 describe('health', function() {
-  var myVault = null;
+  var myVault;
 
   before(function() {
-    myVault = new Vault({
-      vault_host: VAULT_HOST,
-      vault_port: VAULT_PORT,
-      vault_ssl: 0
+    return helpers.getPreparedVault().then(function (vault) {
+      myVault = vault;
     });
-    return myVault.prepare();
   });
 
   it('should reject with Error and statusCode 500 when not initialized or sealed', function () {
@@ -111,12 +105,7 @@ describe('health', function() {
 
   after(function () {
     if (!myVault.status.sealed) {
-      return myVault.seal().then(function () {
-        debuglog('vault sealed: %s', myVault.status.sealed);
-      }).then(null, function (err) {
-        debuglog(err);
-        debuglog('failed to seal vault: %s', err.message);
-      });
+      return helpers.resealVault(myVault);
     }
   });
 

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,9 +1,55 @@
-module.exports = {
+var debuglog = require('util').debuglog('vaulted-tests');
+var _ = require('lodash');
+
+var helpers = module.exports = {
   chai: require('chai'),
   assert: require('chai').assert,
   expect: require('chai').expect,
   should: require('chai').should(),
   cap: require('chai-as-promised'),
+  debuglog: debuglog,
   VAULT_HOST: process.env.VAULT_HOST || 'vault',
   VAULT_PORT: process.env.VAULT_PORT || 8200
+};
+
+var Vault = require('../lib/vaulted');
+
+helpers.getVault = function getVault() {
+  return new Vault({
+    vault_host: this.VAULT_HOST,
+    vault_port: this.VAULT_PORT,
+    vault_ssl: 0
+  });
+};
+
+helpers.getEmptyVault = function getEmptyVault() {
+  return new Vault({});
+};
+
+helpers.getPreparedVault = function getPreparedVault() {
+  return this.getVault().prepare();
+};
+
+helpers.getReadyVault = function getReadyVault() {
+  var myVault = this.getVault();
+
+  return myVault.prepare().bind(myVault)
+    .then(myVault.init)
+    .then(myVault.unSeal)
+    .catch(function onError(err) {
+      debuglog('(before) vault setup failed: %s', err.message);
+    });
+};
+
+helpers.resealVault = function resealVault(vault) {
+  return vault.seal().then(function () {
+    debuglog('vault sealed: %s', vault.status.sealed);
+  }).catch(function (err) {
+    debuglog(err);
+    debuglog('failed to seal vault: %s', err.message);
+  });
+};
+
+helpers.isTrue = function isTrue(value) {
+  return _.isString(value) && (value.toLowerCase() === 'true' || value.toLowerCase() === 'yes');
 };

--- a/tests/init.js
+++ b/tests/init.js
@@ -1,27 +1,20 @@
-require('./helpers.js').should;
+require('./helpers').should;
 
 var
   helpers = require('./helpers'),
-  debuglog = require('util').debuglog('vaulted-tests'),
   chai = helpers.chai,
-  assert = helpers.assert,
-  Vault = require('../lib/vaulted.js');
+  Vault = require('../lib/vaulted');
 
 chai.use(helpers.cap);
 
-var VAULT_HOST = helpers.VAULT_HOST;
-var VAULT_PORT = helpers.VAULT_PORT;
 
 describe('init', function() {
-  var myVault = null;
+  var myVault;
 
   before(function() {
-    myVault = new Vault({
-      vault_host: VAULT_HOST,
-      vault_port: VAULT_PORT,
-      vault_ssl: 0
+    return helpers.getPreparedVault().then(function (vault) {
+      myVault = vault;
     });
-    return myVault.prepare();
   });
 
   it.skip('initialized false', function () {
@@ -36,9 +29,6 @@ describe('init', function() {
         self.initialized.should.be.true;
         self.token.should.not.be.null;
         self.keys.should.not.be.empty;
-    }).then(null, function (err) {
-      debuglog(err);
-      assert.notOk(err, 'no error should ever be returned');
     });
   });
 

--- a/tests/internal.js
+++ b/tests/internal.js
@@ -1,21 +1,18 @@
-require('./helpers.js').should;
+require('./helpers').should;
 
 var
-  helpers = require('./helpers'),
-  debuglog = require('util').debuglog('vaulted-tests'),
   fs = require('fs'),
   os = require('os'),
   path = require('path'),
+  helpers = require('./helpers'),
+  debuglog = helpers.debuglog,
   chai = helpers.chai,
   assert = helpers.assert,
   expect = helpers.expect,
-  Vault = require('../lib/vaulted'),
   internal = require('../lib/internal');
 
 chai.use(helpers.cap);
 
-var VAULT_HOST = helpers.VAULT_HOST;
-var VAULT_PORT = helpers.VAULT_PORT;
 var BACKUP_DIR = path.join(os.homedir(), '.vault');
 var BACKUP_FILE = path.join(BACKUP_DIR, 'keys.json');
 
@@ -27,14 +24,13 @@ var renameFile = function (oldname, newname) {
   }
 };
 
-var initOrRename = function (vault, oldname, newname) {
+var initOrRename = function (vault) {
   return vault.getInitStatus().then(function (result) {
     debuglog('initOrRename result status: %s', result.initialized);
     if (!result.initialized) {
-      debuglog('calling init...');
       return vault.init();
     } else {
-      renameFile(oldname, newname);
+      renameFile('prev-keys.json', 'keys.json');
       return internal.recover(vault);
     }
   });
@@ -43,15 +39,7 @@ var initOrRename = function (vault, oldname, newname) {
 
 
 describe('internal state', function () {
-  var myVault = null;
-
-  before(function () {
-    myVault = new Vault({
-      vault_host: VAULT_HOST,
-      vault_port: VAULT_PORT,
-      vault_ssl: 0
-    });
-  });
+  var myVault = helpers.getVault();
 
   it('loadState - not initialized', function () {
     renameFile('keys.json', 'prev-keys.json');
@@ -60,26 +48,17 @@ describe('internal state', function () {
       myVault.initialized.should.be.false;
       self.keys.should.be.empty;
       myVault.keys.should.be.empty;
-    }).then(null, function (err) {
-      debuglog(err);
-      assert.notOk(err, 'no error should ever be returned');
     });
   });
 
   it('loadState - sealed', function () {
-    return initOrRename(myVault, 'prev-keys.json', 'keys.json').then(function () {
+    return initOrRename(myVault).then(function () {
       return internal.loadState(myVault).then(function (self) {
         self.initialized.should.be.true;
         myVault.initialized.should.be.true;
         self.status.sealed.should.be.true;
         myVault.status.sealed.should.be.true;
-      }).then(null, function (err) {
-        debuglog(err);
-        assert.notOk(err, 'no error should ever be returned');
       });
-    }).then(null, function (err) {
-      debuglog(err);
-      assert.notOk(err, 'failed to init vault');
     });
   });
 
@@ -90,9 +69,6 @@ describe('internal state', function () {
         myVault.initialized.should.be.true;
         self.status.sealed.should.be.false;
         myVault.status.sealed.should.be.false;
-      }).then(null, function (err) {
-        debuglog(err);
-        assert.notOk(err, 'no error should ever be returned');
       });
     });
   });
@@ -107,9 +83,6 @@ describe('internal state', function () {
       myVault.mounts.should.not.be.empty;
       self.mounts.should.contain.keys('sys/');
       myVault.mounts.should.contain.keys('sys/');
-    }).then(null, function (err) {
-      debuglog(err);
-      assert.notOk(err, 'no error should ever be returned');
     });
   });
 
@@ -129,9 +102,6 @@ describe('internal state', function () {
         myVault.mounts.should.not.be.empty;
         self.mounts.should.contain.keys('consul/');
         myVault.mounts.should.contain.keys('consul/');
-      }).then(null, function (err) {
-        debuglog(err);
-        assert.notOk(err, 'no error should ever be returned');
       });
     });
   });
@@ -144,9 +114,6 @@ describe('internal state', function () {
       myVault.initialized.should.be.true;
       self.keys.should.be.empty;
       myVault.keys.should.be.empty;
-    }).then(null, function (err) {
-      debuglog(err);
-      assert.notOk(err, 'no error should ever be returned');
     });
   });
 
@@ -161,9 +128,6 @@ describe('internal state', function () {
         err.should.be.an.instanceof(Error);
         err.code.should.equal('ENOENT');
       }
-    }).then(null, function (err) {
-      debuglog(err);
-      assert.notOk(err, 'no error should ever be returned');
     });
   });
 
@@ -178,9 +142,6 @@ describe('internal state', function () {
         err.code.should.equal('ENOENT');
       }
       myVault.keys = [];
-    }).then(null, function (err) {
-      debuglog(err);
-      assert.notOk(err, 'no error should ever be returned');
     });
   });
 
@@ -193,14 +154,11 @@ describe('internal state', function () {
         err.should.be.an.instanceof(Error);
         err.code.should.equal('ENOENT');
       }
-    }).then(null, function (err) {
-      debuglog(err);
-      assert.notOk(err, 'no error should ever be returned');
     });
   });
 
   it('backup success', function () {
-    return initOrRename(myVault, 'prev-keys.json', 'keys.json').then(function () {
+    return initOrRename(myVault).then(function () {
       return internal.backup(myVault).then(function () {
         try {
           var stats = fs.statSync(BACKUP_FILE);
@@ -211,13 +169,7 @@ describe('internal state', function () {
           debuglog(err);
           assert.notOk(err, 'backup file failed for some reason');
         }
-      }).then(null, function (err) {
-        debuglog(err);
-        assert.notOk(err, 'no error should ever be returned');
       });
-    }).then(null, function (err) {
-      debuglog(err);
-      assert.notOk(err, 'failed to init vault');
     });
   });
 
@@ -242,7 +194,7 @@ describe('internal state', function () {
 
   it('recover - no root token', function () {
     var data = JSON.stringify({
-      "keys": []
+      'keys': []
     });
     fs.writeFileSync(BACKUP_FILE, data);
     return internal.recover(myVault).then(function () {
@@ -253,8 +205,8 @@ describe('internal state', function () {
 
   it('recover - keys not Array', function () {
     var data = JSON.stringify({
-      "root": "xyz",
-      "keys": "abc,xyz"
+      'root': 'xyz',
+      'keys': 'abc,xyz'
     });
     fs.writeFileSync(BACKUP_FILE, data);
     return internal.recover(myVault).then(function () {
@@ -265,8 +217,8 @@ describe('internal state', function () {
 
   it('recover - keys empty Array', function () {
     var data = JSON.stringify({
-      "root": "xyz",
-      "keys": []
+      'root': 'xyz',
+      'keys': []
     });
     fs.writeFileSync(BACKUP_FILE, data);
     return internal.recover(myVault).then(function () {
@@ -289,16 +241,8 @@ describe('internal state', function () {
       id: 'consul'
     }).then(function () {
       if (!myVault.status.sealed) {
-        return myVault.seal().then(function () {
-          debuglog('vault sealed: %s', myVault.status.sealed);
-        }).then(null, function (err) {
-          debuglog(err);
-          debuglog('failed to seal vault: %s', err.message);
-        });
+        return helpers.resealVault(myVault);
       }
-    }).then(null, function (err) {
-      debuglog(err);
-      debuglog('failed to remove consul mount: %s', err.message);
     });
   });
 });

--- a/tests/keys.js
+++ b/tests/keys.js
@@ -1,42 +1,30 @@
-require('./helpers.js').should;
+require('./helpers').should;
 
 var
   helpers = require('./helpers'),
-  debuglog = require('util').debuglog('vaulted-tests'),
+  debuglog = helpers.debuglog,
   _ = require('lodash'),
   chai = helpers.chai,
-  assert = helpers.assert,
   expect = helpers.expect,
-  Vault = require('../lib/vaulted.js');
+  Vault = require('../lib/vaulted');
 
 chai.use(helpers.cap);
 
-var VAULT_HOST = helpers.VAULT_HOST;
-var VAULT_PORT = helpers.VAULT_PORT;
 
 describe('keys', function () {
-  var myVault = null;
+  var newVault = helpers.getEmptyVault();
+  var myVault;
 
   before(function () {
-    myVault = new Vault({
-      vault_host: VAULT_HOST,
-      vault_port: VAULT_PORT,
-      vault_ssl: 0
+    return helpers.getReadyVault().then(function (vault) {
+      myVault = vault;
     });
-
-    return myVault.prepare().bind(myVault)
-      .then(myVault.init)
-      .then(myVault.unSeal)
-      .catch(function onError(err) {
-        debuglog('(before) vault setup failed: %s', err.message);
-      });
 
   });
 
   describe('#getKeyStatus', function () {
 
     it('should reject with an Error if not initialized or unsealed', function () {
-      var newVault = new Vault({});
       return newVault.getKeyStatus().should.be.rejectedWith(/Vault has not been initialized/);
     });
 
@@ -55,7 +43,6 @@ describe('keys', function () {
   describe('#getRekeyStatus', function () {
 
     it('should reject with an Error if not initialized or unsealed', function () {
-      var newVault = new Vault({});
       return newVault.getRekeyStatus().should.be.rejectedWith(/Vault has not been initialized/);
     });
 
@@ -81,7 +68,6 @@ describe('keys', function () {
   describe('#startRekey', function () {
 
     it('should reject with an Error if not initialized or unsealed', function () {
-      var newVault = new Vault({});
       return newVault.startRekey().should.be.rejectedWith(/Vault has not been initialized/);
     });
 
@@ -94,7 +80,6 @@ describe('keys', function () {
   describe('#updateRekey', function () {
 
     it('should reject with an Error if not initialized or unsealed', function () {
-      var newVault = new Vault({});
       return newVault.updateRekey().should.be.rejectedWith(/Vault has not been initialized/);
     });
 
@@ -112,7 +97,6 @@ describe('keys', function () {
   describe('#stopRekey', function () {
 
     it('should reject with an Error if not initialized or unsealed', function () {
-      var newVault = new Vault({});
       return newVault.stopRekey().should.be.rejectedWith(/Vault has not been initialized/);
     });
 
@@ -130,7 +114,6 @@ describe('keys', function () {
   describe('#rotateKey', function () {
 
     it('should reject with an Error if not initialized or unsealed', function () {
-      var newVault = new Vault({});
       return newVault.rotateKey().should.be.rejectedWith(/Vault has not been initialized/);
     });
 
@@ -142,12 +125,7 @@ describe('keys', function () {
 
   after(function () {
     if (!myVault.status.sealed) {
-      return myVault.seal().then(function () {
-        debuglog('vault sealed: %s', myVault.status.sealed);
-      }).then(null, function (err) {
-        debuglog(err);
-        debuglog('failed to seal vault: %s', err.message);
-      });
+      return helpers.resealVault(myVault);
     }
   });
 

--- a/tests/leader.js
+++ b/tests/leader.js
@@ -1,34 +1,20 @@
-require('./helpers.js').should;
+require('./helpers').should;
 
 var
   helpers = require('./helpers'),
-  debuglog = require('util').debuglog('vaulted-tests'),
+  debuglog = helpers.debuglog,
   chai = helpers.chai,
-  expect = helpers.expect
-  Vault = require('../lib/vaulted');
+  expect = helpers.expect;
 
 chai.use(helpers.cap);
-
-var VAULT_HOST = helpers.VAULT_HOST;
-var VAULT_PORT = helpers.VAULT_PORT;
 
 
 describe('leader', function () {
   var myVault;
 
   before(function () {
-    myVault = new Vault({
-      // debug: 1,
-      vault_host: VAULT_HOST,
-      vault_port: VAULT_PORT,
-      vault_ssl: 0
-    });
-
-    return myVault.prepare().bind(myVault)
-    .then(myVault.init)
-    .then(myVault.unSeal)
-    .catch(function onError(err) {
-      debuglog('(before) vault setup failed: %s', err.message);
+    return helpers.getReadyVault().then(function (vault) {
+      myVault = vault;
     });
 
   });
@@ -48,12 +34,7 @@ describe('leader', function () {
 
   after(function () {
     if (!myVault.status.sealed) {
-      return myVault.seal().then(function () {
-        debuglog('vault sealed: %s', myVault.status.sealed);
-      }).then(null, function (err) {
-        debuglog(err);
-        debuglog('failed to seal vault: %s', err.message);
-      });
+      return helpers.resealVault(myVault);
     }
   });
 

--- a/tests/policy.js
+++ b/tests/policy.js
@@ -1,168 +1,117 @@
-require('./helpers.js').should;
+require('./helpers').should;
 
 var
   helpers = require('./helpers'),
-  debuglog = require('util').debuglog('vaulted-tests'),
+  debuglog = helpers.debuglog,
   _ = require('lodash'),
-  chai = helpers.chai,
-  assert = helpers.assert,
-  Vault = require('../lib/vaulted');
+  expect = helpers.expect,
+  chai = helpers.chai;
 
 chai.use(helpers.cap);
 
-var VAULT_HOST = helpers.VAULT_HOST;
-var VAULT_PORT = helpers.VAULT_PORT;
-
 
 describe('policy', function () {
+  var newVault = helpers.getEmptyVault();
   var myVault;
 
   before(function () {
-    myVault = new Vault({
-      // debug: 1,
-      vault_host: VAULT_HOST,
-      vault_port: VAULT_PORT,
-      vault_ssl: 0
+    return helpers.getReadyVault().then(function (vault) {
+      myVault = vault;
     });
-
-    return myVault.prepare().bind(myVault)
-      .then(myVault.init)
-      .then(myVault.unSeal)
-      .catch(function onError(err) {
-        debuglog('(before) vault setup failed: %s', err.message);
-      });
 
   });
 
   describe('#getPolicies', function () {
 
     it('should reject with an Error if not initialized or unsealed', function () {
-      var newVault = new Vault({});
       return newVault.getPolicies().should.be.rejectedWith(/Vault has not been initialized/);
     });
 
     it('should resolve to updated list of policies', function () {
       var existingPolicies = _.cloneDeep(myVault.policies);
       return myVault.getPolicies().then(function (policies) {
+        debuglog(policies);
         existingPolicies.should.be.empty;
         policies.should.not.be.empty;
         existingPolicies.should.not.contain('root');
         policies.should.contain('root');
       });
-    })
+    });
 
   });
 
   describe('#createPolicy', function () {
 
     it('should reject with an Error if not initialized or unsealed', function () {
-      var newVault = new Vault({});
-      var policy = 'key "" { policy = "read" }';
+      var policy = 'path "secret/foo" { policy = "read" }';
       return newVault.createPolicy({
         id: 'other',
         body: {
-          rule: policy
+          rules: policy
         }
       }).should.be.rejectedWith(/Vault has not been initialized/);
     });
 
     it('should reject with an Error if no options provided', function () {
-      return myVault.createPolicy().then(function (policies) {
-        debuglog('createPolicy successful (should fail)', policies);
-        assert.notOk(policies, 'no policy details successfully created!');
-      }).then(null, function (err) {
-        debuglog(err);
-        err.should.be.an.instanceof(Error);
-        err.message.should.equal('You must provide policy id.');
-      });
+      return myVault.createPolicy()
+        .should.be.rejectedWith(/You must provide policy id/);
     });
 
     it('should reject with an Error if option id empty', function () {
       return myVault.createPolicy({
         id: ''
-      }).then(function (policies) {
-        debuglog('createPolicy successful (should fail)', policies);
-        assert.notOk(policies, 'no policy details successfully created!');
-      }).then(null, function (err) {
-        debuglog(err);
-        err.should.be.an.instanceof(Error);
-        err.message.should.equal('You must provide policy id.');
-      });
+      }).should.be.rejectedWith(/You must provide policy id/);
     });
 
     it('should reject with an Error if option body empty', function () {
       return myVault.createPolicy({
         id: 'xyz',
         body: null
-      }).then(function (policies) {
-        debuglog('createPolicy successful (should fail)', policies);
-        assert.notOk(policies, 'no policy details successfully created!');
-      }).then(null, function (err) {
-        debuglog(err);
-        err.should.be.an.instanceof(Error);
-        err.message.should.equal('You must provide policy details.');
-      });
+      }).should.be.rejectedWith(/You must provide policy details/);
     });
 
     it('should reject with an Error if option body without rule', function () {
       return myVault.createPolicy({
         id: 'xyz',
         body: {}
-      }).then(function (policies) {
-        debuglog('createPolicy successful (should fail)', policies);
-        assert.notOk(policies, 'no policy details successfully created!');
-      }).then(null, function (err) {
-        debuglog(err);
-        err.should.be.an.instanceof(Error);
-        err.message.should.equal('You must provide policy rule as string.');
-      });
+      }).should.be.rejectedWith(/You must provide policy rule as string/);
     });
 
     it('should reject with an Error if option body with empty rule', function () {
       return myVault.createPolicy({
         id: 'xyz',
         body: {
-          rule: ''
+          rules: ''
         }
-      }).then(function (policies) {
-        debuglog('createPolicy successful (should fail)', policies);
-        assert.notOk(policies, 'no policy details successfully created!');
-      }).then(null, function (err) {
-        debuglog(err);
-        err.should.be.an.instanceof(Error);
-        err.message.should.equal('You must provide policy rule as string.');
-      });
+      }).should.be.rejectedWith(/You must provide policy rule as string/);
     });
 
     it('should reject with an Error if rule not string', function () {
       return myVault.createPolicy({
         id: 'xyz',
         body: {
-          rule: {}
+          rules: {}
         }
-      }).then(function (policies) {
-        debuglog('createPolicy successful (should fail)', policies);
-        assert.notOk(policies, 'no policy details successfully created!');
-      }).then(null, function (err) {
-        debuglog(err);
-        err.should.be.an.instanceof(Error);
-        err.message.should.equal('You must provide policy rule as string.');
-      });
+      }).should.be.rejectedWith(/You must provide policy rule as string/);
     });
 
     it('should resolve to updated list of policies', function () {
       var existingPolicies = _.cloneDeep(myVault.policies);
-      var policy = 'key "" { policy = "read" }';
+      var policy = 'path "secret/foo" { policy = "read" }';
       return myVault.createPolicy({
         id: 'other',
         body: {
-          rule: policy
+          rules: policy
         }
       }).then(function (policies) {
+        debuglog(policies);
         existingPolicies.should.not.be.empty;
         policies.should.not.be.empty;
         existingPolicies.should.not.contain('other');
         policies.should.contain('other');
+      }).catch(function (err) {
+        debuglog(err);
+        expect(err).to.be.undefined;
       });
     });
 
@@ -171,7 +120,6 @@ describe('policy', function () {
   describe('#deletePolicy', function () {
 
     it('should reject with an Error if not initialized or unsealed', function () {
-      var newVault = new Vault({});
       return newVault.deletePolicy({
         id: 'other'
       }).should.be.rejectedWith(/Vault has not been initialized/);
@@ -190,6 +138,7 @@ describe('policy', function () {
       return myVault.deletePolicy({
         id: 'other'
       }).then(function (policies) {
+        debuglog(policies);
         existingPolicies.should.not.be.empty;
         policies.should.not.be.empty;
         existingPolicies.should.contain('other');
@@ -202,12 +151,7 @@ describe('policy', function () {
 
   after(function () {
     if (!myVault.status.sealed) {
-      return myVault.seal().then(function () {
-        debuglog('vault sealed: %s', myVault.status.sealed);
-      }).then(null, function (err) {
-        debuglog(err);
-        debuglog('failed to seal vault: %s', err.message);
-      });
+      return helpers.resealVault(myVault);
     }
   });
 

--- a/tests/seal.js
+++ b/tests/seal.js
@@ -1,32 +1,20 @@
-require('./helpers.js').should;
+require('./helpers').should;
 
 var
   helpers = require('./helpers'),
-  debuglog = require('util').debuglog('vaulted-tests'),
   _ = require('lodash'),
-  chai = helpers.chai,
-  assert = helpers.assert,
-  expect = helpers.expect,
-  Vault = require('../lib/vaulted');
+  chai = helpers.chai;
 
 chai.use(helpers.cap);
-
-var VAULT_HOST = helpers.VAULT_HOST;
-var VAULT_PORT = helpers.VAULT_PORT;
 
 
 describe('seal', function () {
   var myVault;
 
-  before(function () {
-    myVault = new Vault({
-      // debug: 1,
-      vault_host: VAULT_HOST,
-      vault_port: VAULT_PORT,
-      vault_ssl: 0
+  before(function() {
+    return helpers.getPreparedVault().then(function (vault) {
+      myVault = vault;
     });
-
-    return myVault.prepare();
   });
 
   describe('#getSealedStatus', function () {
@@ -96,12 +84,7 @@ describe('seal', function () {
 
   after(function () {
     if (!myVault.status.sealed) {
-      return myVault.seal().then(function () {
-        debuglog('vault sealed: %s', myVault.status.sealed);
-      }).then(null, function (err) {
-        debuglog(err);
-        debuglog('failed to seal vault: %s', err.message);
-      });
+      return helpers.resealVault(myVault);
     }
   });
 

--- a/tests/secret.js
+++ b/tests/secret.js
@@ -1,42 +1,29 @@
-require('./helpers.js').should;
+require('./helpers').should;
 
 var
   helpers = require('./helpers'),
-  debuglog = require('util').debuglog('vaulted-tests'),
+  debuglog = helpers.debuglog,
   chai = helpers.chai,
   assert = helpers.assert,
-  expect = helpers.expect,
-  Vault = require('../lib/vaulted');
-
-var VAULT_HOST = helpers.VAULT_HOST;
-var VAULT_PORT = helpers.VAULT_PORT;
+  expect = helpers.expect;
 
 chai.use(helpers.cap);
 
 
 describe('secret', function () {
+  var newVault = helpers.getEmptyVault();
   var myVault;
 
   before(function () {
-    myVault = new Vault({
-      // debug: 1,
-      vault_host: VAULT_HOST,
-      vault_port: VAULT_PORT,
-      vault_ssl: 0
+    return helpers.getReadyVault().then(function (vault) {
+      myVault = vault;
     });
 
-    return myVault.prepare().bind(myVault)
-    .then(myVault.init)
-    .then(myVault.unSeal)
-    .catch(function onError(err) {
-      debuglog('(before) vault setup failed: %s', err.message);
-    });
   });
 
   describe('#write', function () {
 
     it('should reject with an Error if not initialized or unsealed', function () {
-      var newVault = new Vault({});
       return newVault.write({
         id: 'sample',
         body: {
@@ -46,43 +33,26 @@ describe('secret', function () {
     });
 
     it('no secret id provided', function () {
-      return myVault.write().then(function () {
-        debuglog('write secret successful (should fail)');
-        assert.notOk(true, 'no secret id successfully created!');
-      }).then(null, function (err) {
-        err.should.be.an.instanceof(Error);
-        err.message.should.equal('You must provide secret id.');
-      });
+      return myVault.write().should.be.rejectedWith(/You must provide secret id/);
     });
 
     it('empty secret id provided', function () {
-      return myVault.write({id: ''}).then(function () {
-        debuglog('write secret successful (should fail)');
-        assert.notOk(true, 'no secret id successfully created!');
-      }).then(null, function (err) {
-        err.should.be.an.instanceof(Error);
-        err.message.should.equal('You must provide secret id.');
-      });
+      return myVault.write({
+        id: ''
+      }).should.be.rejectedWith(/You must provide secret id/);
     });
 
     it('no secret provided', function () {
-      return myVault.write({id: 'dummy'}).then(function () {
-        debuglog('write secret successful (should fail)');
-        assert.notOk(true, 'no secret body successfully created!');
-      }).then(null, function (err) {
-        err.should.be.an.instanceof(Error);
-        err.message.should.equal('You must provide an secret to write to the Vault.');
-      });
+      return myVault.write({
+        id: 'dummy'
+      }).should.be.rejectedWith(/You must provide an secret to write to the Vault/);
     });
 
     it('empty secret provided', function () {
-      return myVault.write({id: 'dummy', body: null}).then(function () {
-        debuglog('write secret successful (should fail)');
-        assert.notOk(true, 'no secret body successfully created!');
-      }).then(null, function (err) {
-        err.should.be.an.instanceof(Error);
-        err.message.should.equal('You must provide an secret to write to the Vault.');
-      });
+      return myVault.write({
+        id: 'dummy',
+        body: null
+      }).should.be.rejectedWith(/You must provide an secret to write to the Vault/);
     });
 
     it('secret written', function () {
@@ -99,32 +69,19 @@ describe('secret', function () {
   describe('#read', function () {
 
     it('should reject with an Error if not initialized or unsealed', function () {
-      var newVault = new Vault({});
       return newVault.read({
         id: 'sample'
       }).should.be.rejectedWith(/Vault has not been initialized/);
     });
 
     it('no secret id provided', function () {
-      return myVault.read().then(function (secret) {
-        debuglog('secret: %s', secret);
-        assert.notOk(secret, 'get secret successful!');
-      }).then(null, function (err) {
-        err.should.be.an.instanceof(Error);
-        err.message.should.equal('You must provide secret id.');
-      });
+      return myVault.read().should.be.rejectedWith(/You must provide secret id/);
     });
 
     it('empty secret id provided', function () {
       return myVault.read({
         id: ''
-      }).then(function (secret) {
-        debuglog('secret: %s', secret);
-        assert.notOk(secret, 'get secret successful!');
-      }).then(null, function (err) {
-        err.should.be.an.instanceof(Error);
-        err.message.should.equal('You must provide secret id.');
-      });
+      }).should.be.rejectedWith(/You must provide secret id/);
     });
 
     it('secret not found', function () {
@@ -157,32 +114,20 @@ describe('secret', function () {
   describe('#delete', function () {
 
     it('should reject with an Error if not initialized or unsealed', function () {
-      var newVault = new Vault({});
       return newVault.delete({
         id: 'sample'
       }).should.be.rejectedWith(/Vault has not been initialized/);
     });
 
     it('no secret id provided', function () {
-      return myVault.delete().then(function () {
-        debuglog('delete should fail but was successful');
-        assert.notOk(true, 'delete secret successful!');
-      }).then(null, function (err) {
-        err.should.be.an.instanceof(Error);
-        err.message.should.equal('You must provide secret id.');
-      });
+      return myVault.delete()
+        .should.be.rejectedWith(/You must provide secret id/);
     });
 
     it('empty secret id provided', function () {
       return myVault.delete({
         id: ''
-      }).then(function () {
-        debuglog('delete should fail but was successful');
-        assert.notOk(true, 'delete secret successful!');
-      }).then(null, function (err) {
-        err.should.be.an.instanceof(Error);
-        err.message.should.equal('You must provide secret id.');
-      });
+      }).should.be.rejectedWith(/You must provide secret id/);
     });
 
     it.skip('secret not deleted', function () {
@@ -207,12 +152,7 @@ describe('secret', function () {
 
   after(function () {
     if (!myVault.status.sealed) {
-      return myVault.seal().then(function () {
-        debuglog('vault sealed: %s', myVault.status.sealed);
-      }).then(null, function (err) {
-        debuglog(err);
-        debuglog('failed to seal vault: %s', err.message);
-      });
+      return helpers.resealVault(myVault);
     }
   });
 

--- a/tests/vaulted.js
+++ b/tests/vaulted.js
@@ -1,48 +1,46 @@
-require('./helpers.js').should;
+require('./helpers').should;
 
 var
   helpers = require('./helpers'),
   _ = require('lodash'),
-  Vault = require('../lib/vaulted.js');
-
-var VAULT_HOST = helpers.VAULT_HOST;
-var VAULT_PORT = helpers.VAULT_PORT;
+  Vault = require('../lib/vaulted');
 
 
-describe('Vaulted', function() {
+describe('Vaulted', function () {
 
-  describe('#constructor', function() {
+  describe('#constructor', function () {
 
     var old_VAULT_ADDR = null;
 
-    before(function() {
+    before(function () {
       if (process.env.VAULT_ADDR) {
         old_VAULT_ADDR = process.env.VAULT_ADDR;
         delete process.env.VAULT_ADDR;
       }
     });
 
-    after(function() {
+    after(function () {
       if (old_VAULT_ADDR) {
         process.env.VAULT_ADDR = old_VAULT_ADDR;
       }
     });
 
-    it('should create a new instance', function() {
+    it('should create a new instance', function () {
       var vault = new Vault();
       vault.should.be.instanceof(Vault);
     });
 
-    it('should take an empty options hash', function() {
+    it('should take an empty options hash', function () {
       var vault = new Vault({});
       vault.should.be.an.instanceof(Vault);
     });
 
-    it('should take an options hash, and override any default settings', function() {
+    it('should take an options hash, and override any default settings', function () {
       var
         options = {
-          'vault_url': 'https://some.other.host:1234',
-          'env': 'test'
+          debug: 1,
+          vault_url: 'https://some.other.host:1234',
+          env: 'test'
         },
         vault = new Vault(options),
         env = vault.config.get('env');
@@ -50,10 +48,10 @@ describe('Vaulted', function() {
       env.should.equal(options.env);
     });
 
-    it('should throw an error when it can\'t find an api definition', function() {
+    it('should throw an error when it can\'t find an api definition', function () {
       function shouldThrow() {
         return new Vault({
-          'prefix': 'vdfsdf4'
+          prefix: 'vdfsdf4'
         });
       }
       shouldThrow.should.throw(Error);
@@ -67,15 +65,7 @@ describe('Vaulted', function() {
   });
 
   describe('#methods', function () {
-    var myVault = null;
-
-    before(function () {
-      myVault = new Vault({
-        vault_host: VAULT_HOST,
-        vault_port: VAULT_PORT,
-        vault_ssl: 0
-      });
-    });
+    var myVault = helpers.getVault();
 
     it('setToken null', function () {
       function shouldThrow() {
@@ -135,13 +125,16 @@ describe('Vaulted', function() {
     });
 
     it('setStatus success', function () {
-      myVault.setStatus({sealed: false});
+      myVault.setStatus({
+        sealed: false
+      });
       myVault.status.sealed.should.be.false;
     });
 
     it('validateEndpoint - no input provided', function () {
       myVault.initialized = true;
       myVault.status.sealed = false;
+
       function shouldThrow() {
         myVault.validateEndpoint();
       }


### PR DESCRIPTION
Refactor some common code into helpers to reduce the amount of code
duplication. Update test cases to follow a similar pattern for checking
if promise was rejected now that all methods are guaranteed to return
a promise.

Adds way to include or exclude syslog test cases depending on setup
of the test Vault.

```
=============================== Coverage summary ======================
Statements   : 99.2% ( 493/497 )
Branches     : 99.18% ( 364/367 )
Functions    : 98.95% ( 94/95 )
Lines        : 99.2% ( 493/497 )
=======================================================================
```
