### PR TITLE
feature(apis): Support require token per API call

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -1,4 +1,5 @@
 debug: DEBUG
+no_global_token: VAULT_NO_GLOBAL_TOKEN
 
 vault_host: VAULT_HOST
 vault_port: VAULT_PORT

--- a/config/default.yml
+++ b/config/default.yml
@@ -7,3 +7,5 @@ ssl_verify: true
 
 secret_shares: 3
 secret_threshold: 2
+
+no_global_token: false

--- a/lib/audit.js
+++ b/lib/audit.js
@@ -20,14 +20,19 @@ module.exports = function extend(Proto) {
  * @method getAuditMounts
  * @desc Gets the list of mounted audit backends for the vault.
  *
+ * @param {Object} [options] - object of options to send to API request
+ * @param {string} [options.token] - the authentication token
  * @resolve {[Mounts]} Resolves with current list of mounted audit backends
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
  */
-Vaulted.getAuditMounts = Promise.method(function getAuditMounts() {
+Vaulted.getAuditMounts = Promise.method(function getAuditMounts(options) {
+  options = options || {};
+
   return this.getAuditEndpoint()
     .get({
-      headers: this.headers
+      headers: this.headers,
+      _token: options.token
     });
 });
 
@@ -41,6 +46,7 @@ Vaulted.getAuditMounts = Promise.method(function getAuditMounts() {
  * @param {string} options.body.type - the type of audit ('file', 'syslog')
  * @param {string} [options.body.description] - a description of the audit backend for operators.
  * @param {Object} [options.body.options] - options for configuring a specific type of audit backend
+ * @param {string} [options.token] - the authentication token
  * @resolve success
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
@@ -52,7 +58,8 @@ Vaulted.enableAudit = Promise.method(function enableAudit(options) {
       headers: this.headers,
       id: options.id,
       body: options.body,
-      _required: options._required
+      _required: options._required,
+      _token: options.token
     });
 
 });
@@ -63,6 +70,7 @@ Vaulted.enableAudit = Promise.method(function enableAudit(options) {
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the audit mount
+ * @param {string} [options.token] - the authentication token
  * @resolve success
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
@@ -72,7 +80,8 @@ Vaulted.disableAudit = Promise.method(function disableAudit(options) {
   return this.getAuditEndpoint()
     .delete({
       headers: this.headers,
-      id: options.id
+      id: options.id,
+      _token: options.token
     });
 });
 
@@ -86,6 +95,7 @@ Vaulted.disableAudit = Promise.method(function disableAudit(options) {
  * @param {string} options.body.path - the directory where to write the audit files
  * @param {string} [options.body.description] - a description of the file audit backend for operators.
  * @param {boolean} [options.body.log_raw=false] - should security sensitive information be logged raw.
+ * @param {string} [options.token] - the authentication token
  * @resolve success
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
@@ -102,7 +112,8 @@ Vaulted.enableFileAudit = Promise.method(function enableFileAudit(options) {
         log_raw: options.body.log_raw || 'false'
       }
     },
-    _required: 'options.path'
+    _required: 'options.path',
+    token: options.token
   };
 
   return this.enableAudit(fileOptions);
@@ -119,6 +130,7 @@ Vaulted.enableFileAudit = Promise.method(function enableFileAudit(options) {
  * @param {string} [options.body.facility=AUTH] - syslog facility to use.
  * @param {string} [options.body.tag=vault] - syslog tag to use.
  * @param {boolean} [options.body.log_raw=false] - should security sensitive information be logged raw.
+ * @param {string} [options.token] - the authentication token
  * @resolve success
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
@@ -135,7 +147,8 @@ Vaulted.enableSyslogAudit = Promise.method(function enableSyslogAudit(options) {
         tag: options.body.tag || 'vault',
         log_raw: options.body.log_raw || 'false'
       }
-    }
+    },
+    token: options.token
   };
 
   return this.enableAudit(syslogOptions);

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -19,14 +19,19 @@ module.exports = function extend(Proto) {
  * @method getAuthMounts
  * @desc Gets the list of authentication backend mounts for the vault and sets internal property accordingly
  *
+ * @param {Object} [options] - object of options to send to API request
+ * @param {string} [options.token] - the authentication token
  * @resolve {[Auths]} Resolves with current list of mounted auth backends
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
  */
-Vaulted.getAuthMounts = Promise.method(function getAuthMounts() {
+Vaulted.getAuthMounts = Promise.method(function getAuthMounts(options) {
+  options = options || {};
+
   return this.getAuthEndpoint()
     .get({
-      headers: this.headers
+      headers: this.headers,
+      _token: options.token
     })
     .promise()
     .bind(this)
@@ -42,6 +47,7 @@ Vaulted.getAuthMounts = Promise.method(function getAuthMounts() {
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the auth mount
+ * @param {string} [options.token] - the authentication token
  * @resolve {[Auths]} Resolves with current list of mounted auth backends
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
@@ -52,7 +58,8 @@ Vaulted.deleteAuthMount = Promise.method(function deleteAuthMount(options) {
   return this.getAuthEndpoint()
     .delete({
       id: options.id,
-      headers: this.headers
+      headers: this.headers,
+      _token: options.token
     })
     .promise()
     .bind(this)
@@ -71,6 +78,7 @@ Vaulted.deleteAuthMount = Promise.method(function deleteAuthMount(options) {
  * @param {Object} options.body - holds the attributes passed as inputs
  * @param {string} options.body.type - the type of auth ('app-id')
  * @param {string} [options.body.description] - a description of the auth backend for operators.
+ * @param {string} [options.token] - the authentication token
  * @resolve {[Auths]} Resolves with current list of mounted auth backends
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
@@ -82,7 +90,8 @@ Vaulted.createAuthMount = Promise.method(function createAuthMount(options) {
     .post({
       headers: this.headers,
       id: options.id,
-      body: options.body
+      body: options.body,
+      _token: options.token
     })
     .promise()
     .bind(this)

--- a/lib/auth/appid.js
+++ b/lib/auth/appid.js
@@ -26,6 +26,7 @@ module.exports = function extend(Proto) {
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the app
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=app-id] - path name the app-id auth backend is mounted on
  * @resolve {App} Resolves with the app details
  * @reject {Error} An error indicating what went wrong
@@ -37,7 +38,8 @@ Vaulted.getApp = Promise.method(function getApp(options, mountName) {
   return this.getAppidMapAppEndpoint(mountName)
     .get({
       headers: this.headers,
-      id: options.id
+      id: options.id,
+      _token: options.token
     });
 });
 
@@ -50,6 +52,7 @@ Vaulted.getApp = Promise.method(function getApp(options, mountName) {
  * @param {Object} options.body - holds the attributes passed as inputs
  * @param {string} options.body.value - the policy id
  * @param {string} options.body.display_name - human-readable name of the app.
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=app-id] - path name the app-id auth backend is mounted on
  * @resolve success
  * @reject {Error} An error indicating what went wrong
@@ -62,7 +65,8 @@ Vaulted.createApp = Promise.method(function createApp(options, mountName) {
     .post({
       headers: this.headers,
       id: options.id,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 });
 
@@ -72,6 +76,7 @@ Vaulted.createApp = Promise.method(function createApp(options, mountName) {
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the app
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=app-id] - path name the app-id auth backend is mounted on
  * @resolve success
  * @reject {Error} An error indicating what went wrong
@@ -83,7 +88,8 @@ Vaulted.deleteApp = Promise.method(function deleteApp(options, mountName) {
   return this.getAppidMapAppEndpoint(mountName)
     .delete({
       headers: this.headers,
-      id: options.id
+      id: options.id,
+      _token: options.token
     });
 });
 
@@ -93,6 +99,7 @@ Vaulted.deleteApp = Promise.method(function deleteApp(options, mountName) {
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the user
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=app-id] - path name the app-id auth backend is mounted on
  * @resolve {User} Resolves with the user details
  * @reject {Error} An error indicating what went wrong
@@ -104,7 +111,8 @@ Vaulted.getUser = Promise.method(function getUser(options, mountName) {
   return this.getAppidMapUserEndpoint(mountName)
     .get({
       headers: this.headers,
-      id: options.id
+      id: options.id,
+      _token: options.token
     });
 });
 
@@ -116,6 +124,7 @@ Vaulted.getUser = Promise.method(function getUser(options, mountName) {
  * @param {string} options.id - unique identifier for the user
  * @param {Object} options.body - holds the attributes passed as inputs
  * @param {string} options.body.value - the app id
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=app-id] - path name the app-id auth backend is mounted on
  * @resolve success
  * @reject {Error} An error indicating what went wrong
@@ -128,7 +137,8 @@ Vaulted.createUser = Promise.method(function createUser(options, mountName) {
     .post({
       headers: this.headers,
       id: options.id,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 });
 
@@ -138,6 +148,7 @@ Vaulted.createUser = Promise.method(function createUser(options, mountName) {
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the user
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=app-id] - path name the app-id auth backend is mounted on
  * @resolve success
  * @reject {Error} An error indicating what went wrong
@@ -149,7 +160,8 @@ Vaulted.deleteUser = Promise.method(function deleteUser(options, mountName) {
   return this.getAppidMapUserEndpoint(mountName)
     .delete({
       headers: this.headers,
-      id: options.id
+      id: options.id,
+      _token: options.token
     });
 });
 
@@ -160,6 +172,7 @@ Vaulted.deleteUser = Promise.method(function deleteUser(options, mountName) {
  * @param {Object} options.body - holds the attributes passed as inputs
  * @param {string} options.body.app_id - the app id
  * @param {string} options.body.user_id - the user id
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=app-id] - path name the app-id auth backend is mounted on
  * @resolve {Auth} Resolves with authentication details including client token.
  * @reject {Error} An error indicating what went wrong
@@ -171,7 +184,8 @@ Vaulted.appLogin = Promise.method(function appLogin(options, mountName) {
   return this.getAppidLoginEndpoint(mountName)
     .post({
       headers: this.headers,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 
 });

--- a/lib/auth/token.js
+++ b/lib/auth/token.js
@@ -43,6 +43,7 @@ module.exports = function extend(Proto) {
  * @param {string} [options.body.ttl] - TTL period of the token
  * @param {string} [options.body.display_name] - display name of the token
  * @param {number} [options.body.num_uses] - maximum uses for the given token
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=token] - path name the token auth backend is mounted on
  * @resolve {Auth} Resolves with token details.
  * @reject {Error} An error indicating what went wrong
@@ -54,7 +55,8 @@ Vaulted.createToken = Promise.method(function createToken(options, mountName) {
   return this.getCreateTokenEndpoint(mountName)
     .post({
       headers: this.headers,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 });
 
@@ -66,6 +68,7 @@ Vaulted.createToken = Promise.method(function createToken(options, mountName) {
  * @param {string} options.id - unique identifier for the token
  * @param {Object} options.body - holds the attributes passed as inputs
  * @param {number} [options.body.increment] - lease increment
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=token] - path name the token auth backend is mounted on
  * @resolve {Auth} Resolves with token details.
  * @reject {Error} An error indicating what went wrong
@@ -78,7 +81,8 @@ Vaulted.renewToken = Promise.method(function renewToken(options, mountName) {
     .post({
       headers: this.headers,
       id: options.id,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 });
 
@@ -88,6 +92,7 @@ Vaulted.renewToken = Promise.method(function renewToken(options, mountName) {
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the token
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=token] - path name the token auth backend is mounted on
  * @resolve {Auth} Resolves with token details.
  * @reject {Error} An error indicating what went wrong
@@ -99,7 +104,8 @@ Vaulted.lookupToken = Promise.method(function lookupToken(options, mountName) {
   return this.getTokenLookupEndpoint(mountName)
     .get({
       headers: this.headers,
-      id: options.id
+      id: options.id,
+      _token: options.token
     });
 });
 
@@ -109,6 +115,7 @@ Vaulted.lookupToken = Promise.method(function lookupToken(options, mountName) {
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the token
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=token] - path name the token auth backend is mounted on
  * @resolve success
  * @reject {Error} An error indicating what went wrong
@@ -120,7 +127,8 @@ Vaulted.revokeToken = Promise.method(function revokeToken(options, mountName) {
   return this.getTokenRevokeEndpoint(mountName)
     .post({
       headers: this.headers,
-      id: options.id
+      id: options.id,
+      _token: options.token
     });
 });
 
@@ -130,6 +138,7 @@ Vaulted.revokeToken = Promise.method(function revokeToken(options, mountName) {
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the token
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=token] - path name the token auth backend is mounted on
  * @resolve success
  * @reject {Error} An error indicating what went wrong
@@ -141,7 +150,8 @@ Vaulted.revokeTokenOrphan = Promise.method(function revokeTokenOrphan(options, m
   return this.getTokenRevokeOrphanEndpoint(mountName)
     .post({
       headers: this.headers,
-      id: options.id
+      id: options.id,
+      _token: options.token
     });
 });
 
@@ -151,6 +161,7 @@ Vaulted.revokeTokenOrphan = Promise.method(function revokeTokenOrphan(options, m
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - token prefix
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=token] - path name the token auth backend is mounted on
  * @resolve success
  * @reject {Error} An error indicating what went wrong
@@ -162,7 +173,8 @@ Vaulted.revokeTokenPrefix = Promise.method(function revokeTokenPrefix(options, m
   return this.getTokenRevokePrefixEndpoint(mountName)
     .post({
       headers: this.headers,
-      id: options.id
+      id: options.id,
+      _token: options.token
     });
 });
 
@@ -170,15 +182,20 @@ Vaulted.revokeTokenPrefix = Promise.method(function revokeTokenPrefix(options, m
  * @method lookupTokenSelf
  * @desc Retrieve information about the current client token.
  *
+ * @param {Object} [options] - object of options to send to API request
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=token] - path name the token auth backend is mounted on
  * @resolve {Auth} Resolves with token details.
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
  */
-Vaulted.lookupTokenSelf = Promise.method(function lookupTokenSelf(mountName) {
+Vaulted.lookupTokenSelf = Promise.method(function lookupTokenSelf(options, mountName) {
+  options = options || {};
+
   return this.getTokenLookupSelfEndpoint(mountName)
     .get({
-      headers: this.headers
+      headers: this.headers,
+      _token: options.token
     });
 });
 
@@ -186,14 +203,19 @@ Vaulted.lookupTokenSelf = Promise.method(function lookupTokenSelf(mountName) {
  * @method revokeTokenSelf
  * @desc Revokes the current client token and all child tokens.
  *
+ * @param {Object} [options] - object of options to send to API request
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=token] - path name the token auth backend is mounted on
  * @resolve success
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
  */
-Vaulted.revokeTokenSelf = Promise.method(function revokeTokenSelf(mountName) {
+Vaulted.revokeTokenSelf = Promise.method(function revokeTokenSelf(options, mountName) {
+  options = options || {};
+
   return this.getTokenRevokeSelfEndpoint(mountName)
     .post({
-      headers: this.headers
+      headers: this.headers,
+      _token: options.token
     });
 });

--- a/lib/backends/consul.js
+++ b/lib/backends/consul.js
@@ -29,6 +29,7 @@ module.exports = function extend(Proto) {
  * @param {string} options.body.address - address of the Consul instance, provided as host:port
  * @param {string} options.body.token - Consul ACL token to use; must be a management type token
  * @param {string} [options.body.scheme=HTTP] - URL scheme to use
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=consul] - path name the consul secret backend is mounted on
  * @resolve success
  * @reject {Error} An error indicating what went wrong
@@ -39,7 +40,8 @@ Vaulted.configConsulAccess = Promise.method(function configConsulAccess(options,
 
   return this.getConsulAccessEndpoint(mountName).post({
     headers: this.headers,
-    body: options.body
+    body: options.body,
+    _token: options.token
   });
 });
 
@@ -53,6 +55,7 @@ Vaulted.configConsulAccess = Promise.method(function configConsulAccess(options,
  * @param {string} options.body.policy - base64 encoded Consul ACL policy
  * @param {string} [options.body.token_type=client] - type of token to create using this role ('client', 'management')
  * @param {string} [options.body.lease] - lease value provided as a string duration with time suffix
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=consul] - path name the consul secret backend is mounted on
  * @resolve success
  * @reject {Error} An error indicating what went wrong
@@ -76,7 +79,8 @@ Vaulted.createConsulRole = Promise.method(function createConsulRole(options, mou
     headers: this.headers,
     id: options.id,
     body: options.body,
-    _override: override
+    _override: override,
+    _token: options.token
   });
 });
 
@@ -86,6 +90,7 @@ Vaulted.createConsulRole = Promise.method(function createConsulRole(options, mou
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the consul role
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=consul] - path name the consul secret backend is mounted on
  * @resolve {Role} Consul role structure
  * @reject {Error} An error indicating what went wrong
@@ -96,7 +101,8 @@ Vaulted.getConsulRole = Promise.method(function getConsulRole(options, mountName
 
   return this.getConsulRolesEndpoint(mountName).get({
     headers: this.headers,
-    id: options.id
+    id: options.id,
+    _token: options.token
   });
 });
 
@@ -106,6 +112,7 @@ Vaulted.getConsulRole = Promise.method(function getConsulRole(options, mountName
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the consul role
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=consul] - path name the consul secret backend is mounted on
  * @resolve success
  * @reject {Error} An error indicating what went wrong
@@ -116,7 +123,8 @@ Vaulted.deleteConsulRole = Promise.method(function deleteConsulRole(options, mou
 
   return this.getConsulRolesEndpoint(mountName).delete({
     headers: this.headers,
-    id: options.id
+    id: options.id,
+    _token: options.token
   });
 });
 
@@ -126,6 +134,7 @@ Vaulted.deleteConsulRole = Promise.method(function deleteConsulRole(options, mou
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the consul role
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=consul] - path name the consul secret backend is mounted on
  * @resolve {Auth} Resolves with token details.
  * @reject {Error} An error indicating what went wrong
@@ -136,6 +145,7 @@ Vaulted.generateConsulRoleToken = Promise.method(function generateConsulRoleToke
 
   return this.getConsulCredsEndpoint(mountName).get({
     headers: this.headers,
-    id: options.id
+    id: options.id,
+    _token: options.token
   });
 });

--- a/lib/backends/cubbyhole.js
+++ b/lib/backends/cubbyhole.js
@@ -22,6 +22,7 @@ module.exports = function extend(Proto) {
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the secret
  * @param {Object} options.body - containing the structure of the secret to store
+ * @param {string} [options.token] - the authentication token
  * @resolve success
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
@@ -33,7 +34,8 @@ Vaulted.writeCubby = Promise.method(function writeCubby(options) {
     .put({
       headers: this.headers,
       id: options.id,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 });
 
@@ -43,6 +45,7 @@ Vaulted.writeCubby = Promise.method(function writeCubby(options) {
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the secret
+ * @param {string} [options.token] - the authentication token
  * @resolve {Secret} Resolves with the secret
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
@@ -53,7 +56,8 @@ Vaulted.readCubby = Promise.method(function readCubby(options) {
   return this.getCubbyEndpoint()
     .get({
       headers: this.headers,
-      id: options.id
+      id: options.id,
+      _token: options.token
     });
 });
 
@@ -63,6 +67,7 @@ Vaulted.readCubby = Promise.method(function readCubby(options) {
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the secret
+ * @param {string} [options.token] - the authentication token
  * @resolve success
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
@@ -73,6 +78,7 @@ Vaulted.deleteCubby = Promise.method(function deleteCubby(options) {
   return this.getCubbyEndpoint()
     .delete({
       headers: this.headers,
-      id: options.id
+      id: options.id,
+      _token: options.token
     });
 });

--- a/lib/backends/pki.js
+++ b/lib/backends/pki.js
@@ -142,6 +142,7 @@ Vaulted.getCertSerial = Promise.method(function getCertSerial(options, mountName
  *
  * @param {Object} options.body - holds the attributes passed as inputs
  * @param {string} options.body.pem_bundle - The key and certificate concatenated in PEM format
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=pki] - path name the pki secret backend is mounted on
  * @resolve success
  * @reject {Error} An error indicating what went wrong
@@ -152,7 +153,8 @@ Vaulted.setConfigCa = Promise.method(function setConfigCa(options, mountName) {
   return this.getPkiConfigCaEndpoint(mountName)
     .post({
       headers: this.headers,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 });
 
@@ -160,15 +162,20 @@ Vaulted.setConfigCa = Promise.method(function setConfigCa(options, mountName) {
  * @method getConfigCrl
  * @desc Allows getting the duration for which the generated CRL should be marked valid
  *
+ * @param {Object} [options] - object of options to send to API request
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=pki] - path name the pki secret backend is mounted on
  * @resolve {Object} CRL duration
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
  */
-Vaulted.getConfigCrl = Promise.method(function getConfigCrl(mountName) {
+Vaulted.getConfigCrl = Promise.method(function getConfigCrl(options, mountName) {
+  options = options || {};
+
   return this.getPkiConfigCrlEndpoint(mountName)
     .get({
-      headers: this.headers
+      headers: this.headers,
+      _token: options.token
     });
 });
 
@@ -178,6 +185,7 @@ Vaulted.getConfigCrl = Promise.method(function getConfigCrl(mountName) {
  *
  * @param {Object} options.body - holds the attributes passed as inputs
  * @param {string} options.body.expiry - The time until expiration
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=pki] - path name the pki secret backend is mounted on
  * @resolve success
  * @reject {Error} An error indicating what went wrong
@@ -191,7 +199,8 @@ Vaulted.setConfigCrl = Promise.method(function setConfigCrl(options, mountName) 
   return this.getPkiConfigCrlEndpoint(mountName)
     .post({
       headers: this.headers,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 });
 
@@ -199,15 +208,20 @@ Vaulted.setConfigCrl = Promise.method(function setConfigCrl(options, mountName) 
  * @method getConfigUrls
  * @desc Fetch the URLs to be encoded in generated certificates
  *
+ * @param {Object} [options] - object of options to send to API request
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=pki] - path name the pki secret backend is mounted on
  * @resolve {Object} URLs
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
  */
-Vaulted.getConfigUrls = Promise.method(function getConfigUrls(mountName) {
+Vaulted.getConfigUrls = Promise.method(function getConfigUrls(options, mountName) {
+  options = options || {};
+
   return this.getPkiConfigUrlsEndpoint(mountName)
     .get({
-      headers: this.headers
+      headers: this.headers,
+      _token: options.token
     });
 });
 
@@ -219,6 +233,7 @@ Vaulted.getConfigUrls = Promise.method(function getConfigUrls(mountName) {
  * @param {string} [options.body.issuing_certificates] - URL values for the Issuing Certificate field
  * @param {string} [options.body.crl_distribution_points] - URL values for the CRL Distribution Points field
  * @param {string} [options.body.ocsp_servers] - URL values for the OCSP Servers field
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=pki] - path name the pki secret backend is mounted on
  * @resolve success
  * @reject {Error} An error indicating what went wrong
@@ -229,7 +244,8 @@ Vaulted.setConfigUrls = Promise.method(function setConfigUrls(options, mountName
   return this.getPkiConfigUrlsEndpoint(mountName)
     .post({
       headers: this.headers,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 });
 
@@ -265,15 +281,20 @@ Vaulted.getCrlPem = Promise.method(function getCrlPem(mountName) {
  * @method getCrlRotate
  * @desc This endpoint forces a rotation of the CRL
  *
+ * @param {Object} [options] - object of options to send to API request
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=pki] - path name the pki secret backend is mounted on
  * @resolve success
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
  */
-Vaulted.getCrlRotate = Promise.method(function getCrlRotate(mountName) {
+Vaulted.getCrlRotate = Promise.method(function getCrlRotate(options, mountName) {
+  options = options || {};
+
   return this.getPkiCrlRotateEndpoint(mountName)
     .get({
-      headers: this.headers
+      headers: this.headers,
+      _token: options.token
     });
 });
 
@@ -288,6 +309,7 @@ Vaulted.getCrlRotate = Promise.method(function getCrlRotate(mountName) {
  * @param {string} [options.body.format=pem] - Format for returned data
  * @param {string} [options.body.key_type=rsa] - Desired key type
  * @param {string} [options.body.key_bits=2048] - The number of bits to use
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=pki] - path name the pki secret backend is mounted on
  * @resolve {Object} CSR and private key
  * @reject {Error} An error indicating what went wrong
@@ -303,7 +325,8 @@ Vaulted.genIntermediatesExported = Promise.method(function genIntermediatesExpor
   return this.getPkiInterGenExtEndpoint(mountName)
     .post({
       headers: this.headers,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 });
 
@@ -318,6 +341,7 @@ Vaulted.genIntermediatesExported = Promise.method(function genIntermediatesExpor
  * @param {string} [options.body.format=pem] - Format for returned data
  * @param {string} [options.body.key_type=rsa] - Desired key type
  * @param {string} [options.body.key_bits=2048] - The number of bits to use
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=pki] - path name the pki secret backend is mounted on
  * @resolve {Object} CSR
  * @reject {Error} An error indicating what went wrong
@@ -333,7 +357,8 @@ Vaulted.genIntermediatesInternal = Promise.method(function genIntermediatesInter
   return this.getPkiInterGenIntEndpoint(mountName)
     .post({
       headers: this.headers,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 });
 
@@ -343,6 +368,7 @@ Vaulted.genIntermediatesInternal = Promise.method(function genIntermediatesInter
  *
  * @param {Object} options.body - holds the attributes passed as inputs
  * @param {string} options.body.certificate - The certificate in PEM format
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=pki] - path name the pki secret backend is mounted on
  * @resolve success
  * @reject {Error} An error indicating what went wrong
@@ -353,7 +379,8 @@ Vaulted.setSignedIntermediates = Promise.method(function setSignedIntermediates(
   return this.getPkiInterSetSignedEndpoint(mountName)
     .post({
       headers: this.headers,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 });
 
@@ -367,6 +394,7 @@ Vaulted.setSignedIntermediates = Promise.method(function setSignedIntermediates(
  * @param {string} [options.body.ip_sans] - Requested IP Subject Alternative Names, in a comma-delimited list
  * @param {string} [options.body.ttl] - Requested Time To Live
  * @param {string} [options.body.format=pem] - Format for returned data
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=pki] - path name the pki secret backend is mounted on
  * @resolve {Object} credentials
  * @reject {Error} An error indicating what went wrong
@@ -381,7 +409,8 @@ Vaulted.issueCertCredentials = Promise.method(function issueCertCredentials(opti
     .post({
       headers: this.headers,
       id: options.id,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 });
 
@@ -391,6 +420,7 @@ Vaulted.issueCertCredentials = Promise.method(function issueCertCredentials(opti
  *
  * @param {Object} options.body - holds the attributes passed as inputs
  * @param {string} options.body.serial_number - serial number of the certificate to revoke
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=pki] - path name the pki secret backend is mounted on
  * @resolve {Object} revocation time
  * @reject {Error} An error indicating what went wrong
@@ -401,7 +431,8 @@ Vaulted.revokeCertCredentials = Promise.method(function revokeCertCredentials(op
   return this.getPkiRevokeEndpoint(mountName)
     .post({
       headers: this.headers,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 });
 
@@ -434,6 +465,7 @@ Vaulted.revokeCertCredentials = Promise.method(function revokeCertCredentials(op
  * @param {string} [options.body.key_bits=2048] - number of bits to use for the generated keys
  * @param {string} [options.body.use_csr_common_name=false] - Designates when used with the CSR signing endpoint,
  * the common name in the CSR will be used instead of taken from the JSON data
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=pki] - path name the pki secret backend is mounted on
  * @resolve success
  * @reject {Error} An error indicating what went wrong
@@ -460,7 +492,8 @@ Vaulted.createCertRole = Promise.method(function createCertRole(options, mountNa
     .post({
       headers: this.headers,
       id: options.id,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 });
 
@@ -470,6 +503,7 @@ Vaulted.createCertRole = Promise.method(function createCertRole(options, mountNa
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - role name
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=pki] - path name the pki secret backend is mounted on
  * @resolve {Object} Role
  * @reject {Error} An error indicating what went wrong
@@ -480,7 +514,8 @@ Vaulted.getCertRole = Promise.method(function getCertRole(options, mountName) {
   return this.getPkiRolesEndpoint(mountName)
     .get({
       headers: this.headers,
-      id: options.id
+      id: options.id,
+      _token: options.token
     });
 });
 
@@ -490,6 +525,7 @@ Vaulted.getCertRole = Promise.method(function getCertRole(options, mountName) {
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - role name
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=pki] - path name the pki secret backend is mounted on
  * @resolve success
  * @reject {Error} An error indicating what went wrong
@@ -500,7 +536,8 @@ Vaulted.deleteCertRole = Promise.method(function deleteCertRole(options, mountNa
   return this.getPkiRolesEndpoint(mountName)
     .delete({
       headers: this.headers,
-      id: options.id
+      id: options.id,
+      _token: options.token
     });
 });
 
@@ -517,6 +554,7 @@ Vaulted.deleteCertRole = Promise.method(function deleteCertRole(options, mountNa
  * @param {string} [options.body.key_type=rsa] - Desired key type
  * @param {string} [options.body.key_bits=2048] - The number of bits to use
  * @param {string} [options.body.max_path_length=-1] - the maximum path length to encode in the generated certificate
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=pki] - path name the pki secret backend is mounted on
  * @resolve {Object} Certificate and Private Key
  * @reject {Error} An error indicating what went wrong
@@ -533,7 +571,8 @@ Vaulted.genRootExported = Promise.method(function genRootExported(options, mount
   return this.getPkiRootGenExtEndpoint(mountName)
     .post({
       headers: this.headers,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 });
 
@@ -550,6 +589,7 @@ Vaulted.genRootExported = Promise.method(function genRootExported(options, mount
  * @param {string} [options.body.key_type=rsa] - Desired key type
  * @param {string} [options.body.key_bits=2048] - The number of bits to use
  * @param {string} [options.body.max_path_length=-1] - the maximum path length to encode in the generated certificate
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=pki] - path name the pki secret backend is mounted on
  * @resolve {Object} Certificate
  * @reject {Error} An error indicating what went wrong
@@ -566,7 +606,8 @@ Vaulted.genRootInternal = Promise.method(function genRootInternal(options, mount
   return this.getPkiRootGenIntEndpoint(mountName)
     .post({
       headers: this.headers,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 });
 
@@ -588,6 +629,7 @@ Vaulted.genRootInternal = Promise.method(function genRootInternal(options, mount
  * 2) Any key usages (for instance, non-repudiation) requested in the CSR will be added to the basic
  * set of key usages used for CA certs signed by this path;
  * 3) Extensions requested in the CSR will be copied into the issued certificate
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=pki] - path name the pki secret backend is mounted on
  * @resolve {Object} Certificate
  * @reject {Error} An error indicating what went wrong
@@ -602,7 +644,8 @@ Vaulted.signIntermediateWithRoot = Promise.method(function signIntermediateWithR
   return this.getPkiRootSignInterEndpoint(mountName)
     .post({
       headers: this.headers,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 });
 
@@ -619,6 +662,7 @@ Vaulted.signIntermediateWithRoot = Promise.method(function signIntermediateWithR
  * @param {string} [options.body.ip_sans] - Requested IP Subject Alternative Names, in a comma-delimited list
  * @param {string} [options.body.ttl] - Requested Time To Live
  * @param {string} [options.body.format=pem] - Format for returned data
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=pki] - path name the pki secret backend is mounted on
  * @resolve {Object} Certificate
  * @reject {Error} An error indicating what went wrong
@@ -633,7 +677,8 @@ Vaulted.signCertificate = Promise.method(function signCertificate(options, mount
     .post({
       headers: this.headers,
       id: options.id,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 });
 
@@ -645,6 +690,7 @@ Vaulted.signCertificate = Promise.method(function signCertificate(options, mount
  * @param {string} options.body.csr - The PEM-encoded CSR
  * @param {string} [options.body.ttl] - Requested Time To Live
  * @param {string} [options.body.format=pem] - Format for returned data
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=pki] - path name the pki secret backend is mounted on
  * @resolve {Object} Certificate
  * @reject {Error} An error indicating what went wrong
@@ -658,6 +704,7 @@ Vaulted.signCertificateVerbatim = Promise.method(function signCertificateVerbati
   return this.getPkiSignVerbatimEndpoint(mountName)
     .post({
       headers: this.headers,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 });

--- a/lib/config.js
+++ b/lib/config.js
@@ -30,7 +30,8 @@ var ALL_OPTIONS = [
   'timeout',
   'secret_shares',
   'secret_threshold',
-  'backup_dir'
+  'backup_dir',
+  'no_global_token'
 ];
 
 /**

--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -9,6 +9,71 @@ var
  *
  */
 
+function validateHeader(verb, options) {
+  // if header not provided then no need to check anything
+  if (_.has(options, 'headers')) {
+    var token = options._token;
+    delete options._token;
+
+    if (token) {
+      options.headers = {
+        'X-Vault-Token': token
+      };
+    }
+
+    if (_.isEmpty(options.headers)) {
+      throw new Error('Missing auth token');
+    }
+  }
+
+  return options;
+}
+
+function validateId(verb, options) {
+  var idRequired = false;
+
+  if (_.has(options, '_required') && options._required === 'id') {
+    idRequired = true;
+    delete options._required;
+  }
+
+  if ((verb.id === true || idRequired) &&
+    (_.isUndefined(options.id) || !options.id)) {
+    throw new Error('Endpoint requires an id.');
+  }
+
+  return options;
+}
+
+function validateBody(verb, options) {
+  var ctxreq;
+
+  if (!_.isEmpty(verb.params)) {
+    ctxreq = options._required;
+    delete options._required;
+
+    // check the params
+    _.forEach(verb.params, function (param) {
+      // check for required attributes
+      if (param.required === true && !_.get(options, '_override', false) && (
+          _.isEmpty(options.body) ||
+          _.isUndefined(options.body[param.name]) ||
+          !options.body[param.name])) {
+        throw new Error('Missing required input ' + param.name);
+      }
+    });
+
+    if (_.isString(ctxreq) && (
+        _.isEmpty(options.body) ||
+        _.isUndefined(_.get(options.body, ctxreq)) ||
+        !_.get(options.body, ctxreq))) {
+      throw new Error('Missing required input ' + ctxreq);
+    }
+  }
+
+  return options;
+}
+
 
 /**
  * Setup function for Endpoint module; provides debug support and returns
@@ -33,6 +98,8 @@ module.exports = function setup(config) {
  */
 function Endpoint(options) {
   options = options || {};
+
+  this.hooks = [];
 
   this.defaults = {};
   if (!_.isEmpty(options.defaults)) {
@@ -69,7 +136,17 @@ Endpoint.create = function create(url, defaults, apis, verbs, name) {
     name: name,
     verbs: verbs
   });
+
+  apis[name].use(validateHeader);
+  apis[name].use(validateId);
+  apis[name].use(validateBody);
+
   return apis;
+};
+
+Endpoint.prototype.use = function use(fn) {
+  this.hooks.push(fn);
+  return this;
 };
 
 /**
@@ -105,55 +182,20 @@ Endpoint.prototype._createRequest = function _createRequest(verb, options) {
   return rp(request_opts);
 };
 
-Endpoint.prototype._validateRequest = function _validateRequest(method, options) {
-  options = options || {};
-  var
-    verb = this.verbs[method],
-    ctxreq;
+_.each(['get', 'post', 'put', 'delete'], function makeMethods(method) {
+  Endpoint.prototype[method] = function (options) {
+    options = options || {};
+    var verb = this.verbs[method];
 
-  // capture additional required based on context
-  ctxreq = options._required;
-  delete options._required;
-
-  if (!method || _.isUndefined(verb)) {
-    throw new Error('Unsupported method ' + method + ' for API ' + this.name);
-  }
-
-  if ((verb.id === true || ctxreq === 'id') &&
-      (_.isUndefined(options.id) || !options.id)) {
-    throw new Error('Endpoint ' + method + ' ' + this.name + ' requires an id.');
-  }
-
-  if (!_.isEmpty(verb.params)) {
-    if (ctxreq === 'id') {
-      ctxreq = undefined;
+    if (!method || _.isUndefined(verb)) {
+      throw new Error('Unsupported method ' + method + ' for API ' + this.name);
     }
 
-    // check the params
-    _.forEach(verb.params, function (param) {
-      // check for required attributes
-      if (param.required === true && !_.get(options, '_override', false) && (
-          _.isEmpty(options.body) ||
-          _.isUndefined(options.body[param.name]) ||
-          !options.body[param.name])) {
-        throw new Error('Missing required input ' + param.name);
-      }
+    _.forEach(this.hooks, function (fn) {
+      options = fn(verb, options);
     });
 
-    if (_.isString(ctxreq) && (
-        _.isEmpty(options.body) ||
-        _.isUndefined(_.get(options.body, ctxreq)) ||
-        !_.get(options.body, ctxreq))) {
-      throw new Error('Missing required input ' + ctxreq);
-    }
-  }
-
-  options.method = method.toUpperCase();
-  return this._createRequest(verb, options);
-};
-
-_.each(['get', 'post', 'put', 'delete'], function makeMethods(verb) {
-  Endpoint.prototype[verb] = function (options) {
-    return this._validateRequest(verb, options);
+    options.method = method.toUpperCase();
+    return this._createRequest(verb, options);
   };
 });

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -23,14 +23,19 @@ module.exports = function extend(Proto) {
  * @method getKeyStatus
  * @desc Gets the status of the current key
  *
+ * @param {Object} [options] - object of options to send to API request
+ * @param {string} [options.token] - the authentication token
  * @resolve {Status} Resolves with the vault key status.
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
  */
-Vaulted.getKeyStatus = Promise.method(function getKeyStatus() {
+Vaulted.getKeyStatus = Promise.method(function getKeyStatus(options) {
+  options = options || {};
+
   return this.getKeyStatusEndpoint()
     .get({
-      headers: this.headers
+      headers: this.headers,
+      _token: options.token
     });
 });
 
@@ -38,14 +43,19 @@ Vaulted.getKeyStatus = Promise.method(function getKeyStatus() {
  * @method rotateKey
  * @desc Initiate the rotation of the encryption key for data stored in the vault
  *
+ * @param {Object} [options] - object of options to send to API request
+ * @param {string} [options.token] - the authentication token
  * @resolve success
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
  */
-Vaulted.rotateKey = Promise.method(function rotateKey() {
+Vaulted.rotateKey = Promise.method(function rotateKey(options) {
+  options = options || {};
+
   return this.getKeyRotateEndpoint()
     .put({
-      headers: this.headers
+      headers: this.headers,
+      _token: options.token
     });
 });
 
@@ -53,14 +63,19 @@ Vaulted.rotateKey = Promise.method(function rotateKey() {
  * @method getRekeyStatus
  * @desc Gets the status of the rekey process.
  *
+ * @param {Object} [options] - object of options to send to API request
+ * @param {string} [options.token] - the authentication token
  * @resolve {Status} Resolves with the vault rekey status.
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
  */
-Vaulted.getRekeyStatus = Promise.method(function getRekeyStatus() {
+Vaulted.getRekeyStatus = Promise.method(function getRekeyStatus(options) {
+  options = options || {};
+
   return this.getRekeyInitEndpoint()
     .get({
-      headers: this.headers
+      headers: this.headers,
+      _token: options.token
     });
 });
 
@@ -71,6 +86,7 @@ Vaulted.getRekeyStatus = Promise.method(function getRekeyStatus() {
  * @param {Object} options - object of options to send to API request
  * @param {number} [options.secret_shares=config['secret_shares']] - number of shares to split the master key into
  * @param {number} [options.secret_threshold=config['secret_threshold']] - number of shares required to reconstruct the master key
+ * @param {string} [options.token] - the authentication token
  * @resolve success
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
@@ -85,7 +101,8 @@ Vaulted.startRekey = Promise.method(function startRekey(options) {
   return this.getRekeyInitEndpoint()
     .put({
       headers: this.headers,
-      body: options
+      body: options,
+      _token: options.token
     });
 });
 
@@ -93,14 +110,19 @@ Vaulted.startRekey = Promise.method(function startRekey(options) {
  * @method stopRekey
  * @desc Stops/Cancels the current rekey process.
  *
+ * @param {Object} [options] - object of options to send to API request
+ * @param {string} [options.token] - the authentication token
  * @resolve success
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
  */
-Vaulted.stopRekey = Promise.method(function stopRekey() {
+Vaulted.stopRekey = Promise.method(function stopRekey(options) {
+  options = options || {};
+
   return this.getRekeyInitEndpoint()
     .delete({
-      headers: this.headers
+      headers: this.headers,
+      _token: options.token
     });
 });
 
@@ -108,18 +130,22 @@ Vaulted.stopRekey = Promise.method(function stopRekey() {
  * @method updateRekey
  * @desc Sends the next key share to continue the rekey process.
  *
+ * @param {Object} [options] - object of options to send to API request
+ * @param {string} [options.token] - the authentication token
  * @resolve {Vaulted} Resolves with current instance of Vaulted after capturing the keys and token
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
  */
-Vaulted.updateRekey = Promise.method(function updateRekey() {
+Vaulted.updateRekey = Promise.method(function updateRekey(options) {
+  options = options || {};
 
   return this.getRekeyUpdateEndpoint()
     .put({
       headers: this.headers,
       body: {
         key: _.sample(this.keys)
-      }
+      },
+      _token: options.token
     })
     .promise()
     .bind(this)
@@ -128,7 +154,7 @@ Vaulted.updateRekey = Promise.method(function updateRekey() {
         this.setKeys(status.keys);
         return internal.backup(this);
       }
-      return this.updateRekey();
+      return this.updateRekey(options);
     });
 
 });

--- a/lib/leader.js
+++ b/lib/leader.js
@@ -19,13 +19,18 @@ module.exports = function extend(Proto) {
  * @method getInitStatus
  * @desc Gets the leader of a vault
  *
+ * @param {Object} [options] - object of options to send to API request
+ * @param {string} [options.token] - the authentication token
  * @resolve {Leader} Resolves with the vault leader
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
  */
-Vaulted.getLeader = Promise.method(function getLeader() {
+Vaulted.getLeader = Promise.method(function getLeader(options) {
+  options = options || {};
+
   return this.getLeaderEndpoint()
     .get({
-      headers: this.headers
+      headers: this.headers,
+      _token: options.token
     });
 });

--- a/lib/leases.js
+++ b/lib/leases.js
@@ -25,6 +25,7 @@ module.exports = function extend(Proto) {
  * @param {string} options.id - unique identifier for the lease
  * @param {Object} [options.body] - holds the attributes passed as inputs
  * @param {string} [options.body.increment] - requested amount of time in seconds to extend the lease.
+ * @param {string} [options.token] - the authentication token
  * @return {Promise<Object>} Promise which is resolved to the renewed secret.
  */
 Vaulted.renewLease = Promise.method(function renewLease(options) {
@@ -34,7 +35,8 @@ Vaulted.renewLease = Promise.method(function renewLease(options) {
     .put({
       headers: this.headers,
       id: options.id,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 });
 
@@ -44,6 +46,7 @@ Vaulted.renewLease = Promise.method(function renewLease(options) {
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the lease
+ * @param {string} [options.token] - the authentication token
  * @resolve success
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
@@ -54,7 +57,8 @@ Vaulted.revokeLease = Promise.method(function revokeLease(options) {
   return this.getLeaseRevokeEndpoint()
     .put({
       headers: this.headers,
-      id: options.id
+      id: options.id,
+      _token: options.token
     });
 });
 
@@ -64,6 +68,7 @@ Vaulted.revokeLease = Promise.method(function revokeLease(options) {
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the lease
+ * @param {string} [options.token] - the authentication token
  * @resolve success
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
@@ -74,6 +79,7 @@ Vaulted.revokeLeasePrefix = Promise.method(function revokeLeasePrefix(options) {
   return this.getLeaseRevokePrefixEndpoint()
     .put({
       headers: this.headers,
-      id: options.id
+      id: options.id,
+      _token: options.token
     });
 });

--- a/lib/mounts.js
+++ b/lib/mounts.js
@@ -21,14 +21,19 @@ module.exports = function extend(Proto) {
  * @method getMounts
  * @desc Gets the list of mounts for the vault and sets internal property accordingly
  *
+ * @param {Object} [options] - object of options to send to API request
+ * @param {string} [options.token] - the authentication token
  * @resolve {[Mounts]} Resolves with current list of mounted secret backends
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
  */
-Vaulted.getMounts = Promise.method(function getMounts() {
+Vaulted.getMounts = Promise.method(function getMounts(options) {
+  options = utils.setDefaults(options);
+
   return this.getMountsEndpoint()
     .get({
-      headers: this.headers
+      headers: this.headers,
+      _token: options.token
     })
     .promise()
     .bind(this)
@@ -44,6 +49,7 @@ Vaulted.getMounts = Promise.method(function getMounts() {
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the secret backend mount
+ * @param {string} [options.token] - the authentication token
  * @resolve {[Mounts]} Resolves with current list of mounted secret backends
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
@@ -53,7 +59,8 @@ Vaulted.deleteMount = Promise.method(function deleteMount(options) {
   return this.getMountsEndpoint()
     .delete({
       id: options.id,
-      headers: this.headers
+      headers: this.headers,
+      _token: options.token
     })
     .promise()
     .bind(this)
@@ -72,6 +79,7 @@ Vaulted.deleteMount = Promise.method(function deleteMount(options) {
  * @param {Object} options.body - holds the attributes passed as inputs
  * @param {string} options.body.type - the type of secret backend ('consul', 'pki')
  * @param {string} [options.body.description] - a description of the secret backend for operators.
+ * @param {string} [options.token] - the authentication token
  * @resolve {[Mounts]} Resolves with current list of mounted secret backends
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
@@ -82,7 +90,8 @@ Vaulted.createMount = Promise.method(function createMount(options) {
     .post({
       headers: this.headers,
       id: options.id,
-      body: options.body
+      body: options.body,
+      _token: options.token
     })
     .promise()
     .bind(this)
@@ -99,6 +108,7 @@ Vaulted.createMount = Promise.method(function createMount(options) {
  * @param {Object} options - object of options to send to API request
  * @param {string} options.from - current unique identifier for the secret backend mount
  * @param {string} options.to - new unique identifier for the secret backend mount
+ * @param {string} [options.token] - the authentication token
  * @resolve {[Mounts]} Resolves with current list of mounted secret backends
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
@@ -110,7 +120,8 @@ Vaulted.reMount = Promise.method(function reMount(options) {
   return this.getRemountEndpoint()
     .post({
       headers: this.headers,
-      body: options
+      body: options,
+      _token: options.token
     })
     .promise()
     .bind(this)
@@ -129,6 +140,7 @@ Vaulted.reMount = Promise.method(function reMount(options) {
  * @param {string} [options.id=consul] - unique identifier for the secret backend mount
  * @param {Object} [options.body] - holds the attributes passed as inputs
  * @param {string} [options.body.description] - a description of the secret backend for operators.
+ * @param {string} [options.token] - the authentication token
  * @resolve {[Mounts]} Resolves with current list of mounted secret backends
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
@@ -143,7 +155,8 @@ Vaulted.mountConsul = Promise.method(function mountConsul(options) {
 
   return this.createMount({
     id: options.id,
-    body: options.body
+    body: options.body,
+    token: options.token
   });
 });
 
@@ -155,6 +168,7 @@ Vaulted.mountConsul = Promise.method(function mountConsul(options) {
  * @param {string} [options.id=pki] - unique identifier for the secret backend mount
  * @param {Object} [options.body] - holds the attributes passed as inputs
  * @param {string} [options.body.description] - a description of the secret backend for operators.
+ * @param {string} [options.token] - the authentication token
  * @resolve {[Mounts]} Resolves with current list of mounted secret backends
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
@@ -169,6 +183,7 @@ Vaulted.mountPki = Promise.method(function mountPki(options) {
 
   return this.createMount({
     id: options.id,
-    body: options.body
+    body: options.body,
+    token: options.token
   });
 });

--- a/lib/policy.js
+++ b/lib/policy.js
@@ -20,14 +20,19 @@ module.exports = function extend(Proto) {
  * @method getPolicies
  * @desc Gets the list of policies for the vault and sets internal property accordingly
  *
+ * @param {Object} [options] - object of options to send to API request
+ * @param {string} [options.token] - the authentication token
  * @resolve {[Policy]} Resolves with list of policy.
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
  */
-Vaulted.getPolicies = Promise.method(function getPolicies() {
+Vaulted.getPolicies = Promise.method(function getPolicies(options) {
+  options = options || {};
+
   return this.getPolicyEndpoint()
     .get({
-      headers: this.headers
+      headers: this.headers,
+      _token: options.token
     })
     .promise()
     .bind(this)
@@ -43,6 +48,7 @@ Vaulted.getPolicies = Promise.method(function getPolicies() {
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the policy
+ * @param {string} [options.token] - the authentication token
  * @resolve {[Policy]} Resolves with policy.
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
@@ -54,7 +60,8 @@ Vaulted.getPolicy = Promise.method(function getPolicy(options) {
     .get({
       headers: this.headers,
       id: options.id,
-      _required: 'id'
+      _required: 'id',
+      _token: options.token
     });
 });
 
@@ -66,6 +73,7 @@ Vaulted.getPolicy = Promise.method(function getPolicy(options) {
  * @param {string} options.id - unique identifier for the policy
  * @param {Object} options.body - holds the attributes passed as inputs
  * @param {string} options.body.rules - the definition of the policy rules (HCL or json format)
+ * @param {string} [options.token] - the authentication token
  * @resolve {[Policy]} Resolves with list of policy.
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
@@ -81,7 +89,8 @@ Vaulted.createPolicy = Promise.method(function createPolicy(options) {
     .put({
       headers: this.headers,
       id: options.id,
-      body: options.body
+      body: options.body,
+      _token: options.token
     })
     .promise()
     .bind(this)
@@ -94,6 +103,7 @@ Vaulted.createPolicy = Promise.method(function createPolicy(options) {
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the policy
+ * @param {string} [options.token] - the authentication token
  * @resolve {[Policy]} Resolves with list of policy.
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
@@ -104,7 +114,8 @@ Vaulted.deletePolicy = Promise.method(function deletePolicy(options) {
   return this.getPolicyEndpoint()
     .delete({
       id: options.id,
-      headers: this.headers
+      headers: this.headers,
+      _token: options.token
     })
     .promise()
     .bind(this)

--- a/lib/seal.js
+++ b/lib/seal.js
@@ -35,11 +35,15 @@ Vaulted.getSealedStatus = Promise.method(function getSealedStatus() {
  * @method seal
  * @desc Seals the vault
  *
+ * @param {Object} [options] - object of options to send to API request
+ * @param {string} [options.token] - the authentication token
  * @resolve {Vaulted} Resolves with current instance of Vaulted
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
  */
-Vaulted.seal = Promise.method(function() {
+Vaulted.seal = Promise.method(function(options) {
+  options = options || {};
+
   if (!this.initialized) {
     return Promise.reject(new Error('Vault has not been initialized.'));
   }
@@ -48,7 +52,8 @@ Vaulted.seal = Promise.method(function() {
   }
   return this.api.getEndpoint('sys/seal')
     .put({
-      headers: this.headers
+      headers: this.headers,
+      _token: options.token
     })
     .promise()
     .bind(this)

--- a/lib/secret.js
+++ b/lib/secret.js
@@ -23,6 +23,7 @@ module.exports = function extend(Proto) {
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the secret
  * @param {Object} options.body - containing the structure of the secret to store
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=secret] - path name the generic secret backend is mounted on
  * @resolve success
  * @reject {Error} An error indicating what went wrong
@@ -35,7 +36,8 @@ Vaulted.write = Promise.method(function writeSecret(options, mountName) {
     .put({
       headers: this.headers,
       id: options.id,
-      body: options.body
+      body: options.body,
+      _token: options.token
     });
 });
 
@@ -45,6 +47,7 @@ Vaulted.write = Promise.method(function writeSecret(options, mountName) {
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the secret
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=secret] - path name the generic secret backend is mounted on
  * @resolve {Secret} Resolves with the secret
  * @reject {Error} An error indicating what went wrong
@@ -56,7 +59,8 @@ Vaulted.read = Promise.method(function readSecret(options, mountName) {
   return this.getSecretEndpoint(mountName)
     .get({
       headers: this.headers,
-      id: options.id
+      id: options.id,
+      _token: options.token
     });
 });
 
@@ -66,6 +70,7 @@ Vaulted.read = Promise.method(function readSecret(options, mountName) {
  *
  * @param {Object} options - object of options to send to API request
  * @param {string} options.id - unique identifier for the secret
+ * @param {string} [options.token] - the authentication token
  * @param {string} [mountName=secret] - path name the generic secret backend is mounted on
  * @resolve success
  * @reject {Error} An error indicating what went wrong
@@ -77,6 +82,7 @@ Vaulted.delete = Promise.method(function deleteSecret(options, mountName) {
   return this.getSecretEndpoint(mountName)
     .delete({
       headers: this.headers,
-      id: options.id
+      id: options.id,
+      _token: options.token
     });
 });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,7 +15,7 @@ function fileExists(location) {
 }
 
 utils.setDefaults = function setDefaults(options, defaults) {
-  options = options || {};
+  options = _.isPlainObject(options) ? options : {};
   defaults = defaults || {};
   if (!_.isPlainObject(options.body)) {
     options.body = {};

--- a/lib/vaulted.js
+++ b/lib/vaulted.js
@@ -79,10 +79,12 @@ Vaulted.prototype.setToken = function setToken(vault_token) {
   if (!_.isString(vault_token) || vault_token.length === 0) {
     throw new Error('Vault token not provided, or has zero-length.');
   }
-  this.token = vault_token;
-  this.headers = {
-    'X-Vault-Token': this.token
-  };
+  if (!this.config.has('no_global_token') || this.config.get('no_global_token') !== true) {
+    this.token = vault_token;
+    this.headers = {
+      'X-Vault-Token': this.token
+    };
+  }
   // having token means being initialized
   this.initialized = true;
   return this;

--- a/tests/endpoint.js
+++ b/tests/endpoint.js
@@ -120,11 +120,7 @@ describe('Endpoint', function () {
     var endpoint;
 
     beforeEach(function () {
-      endpoint = new Endpoint({
-        base_url: BASE_URL,
-        name: 'punts',
-        verbs: api_def.punts
-      });
+      endpoint = Endpoint.create(BASE_URL, {}, {}, api_def.punts, 'punts')['punts'];
     });
 
     it('should have a get method', function () {
@@ -168,11 +164,8 @@ describe('Endpoint', function () {
 
     it('should reject promise if endpoint requires id and one is not provided', function () {
       function shouldThrow() {
-        endpoint = new Endpoint({
-          base_url: BASE_URL,
-          name: 'sys/no_get/:id',
-          verbs: api_def['sys/no_get/:id']
-        });
+        endpoint = Endpoint.create(
+          BASE_URL, {}, {}, api_def['sys/no_get/:id'], 'sys/no_get/:id')['sys/no_get/:id'];
         endpoint.put();
       }
       shouldThrow.should.throw(/requires an id/);

--- a/tests/zzzseal.js
+++ b/tests/zzzseal.js
@@ -22,9 +22,14 @@ describe('#seal', function () {
     return newVault.seal().should.be.rejectedWith(/Vault has not been initialized/);
   });
 
+  it('should be rejected with Error - missing token', function () {
+    myVault.headers = {};
+    return myVault.seal().should.be.rejectedWith(/Missing auth token/);
+  });
+
   it('should resolve to binded instance - success', function () {
     var existing = _.cloneDeep(myVault.status);
-    return myVault.seal().then(function (self) {
+    return myVault.seal({token: myVault.token}).then(function (self) {
       existing.should.have.property('sealed');
       existing.sealed.should.be.false;
       self.status.should.have.property('sealed');
@@ -34,7 +39,7 @@ describe('#seal', function () {
 
   it('should resolve to binded instance - already sealed', function () {
     var existing = _.cloneDeep(myVault.status);
-    return myVault.seal().then(function (self) {
+    return myVault.seal({token: myVault.token}).then(function (self) {
       existing.should.have.property('sealed');
       existing.sealed.should.be.true;
       self.status.should.have.property('sealed');


### PR DESCRIPTION
Adds the ability to configure requiring token per API call using the
option `no_global_tokens`. Avoid accidentally using the root token
for every call and creating a security hole.

closes #54 
