### PR TITLE
chore(project): Refactor hooks plumbing

### DIFF
--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -1,7 +1,10 @@
 var
   _ = require('lodash'),
   rp = require('request-promise'),
-  path = require('path');
+  path = require('path'),
+  Hooks = require('./hooks');
+
+var hooks = new Hooks();
 
 /**
  * @module endpoint
@@ -29,6 +32,8 @@ function validateHeader(verb, options) {
   return options;
 }
 
+hooks.pre('_createRequest', validateHeader);
+
 function validateId(verb, options) {
   var idRequired = false;
 
@@ -44,6 +49,8 @@ function validateId(verb, options) {
 
   return options;
 }
+
+hooks.pre('_createRequest', validateId);
 
 function validateBody(verb, options) {
   var ctxreq;
@@ -74,6 +81,7 @@ function validateBody(verb, options) {
   return options;
 }
 
+hooks.pre('_createRequest', validateBody);
 
 /**
  * Setup function for Endpoint module; provides debug support and returns
@@ -98,8 +106,6 @@ module.exports = function setup(config) {
  */
 function Endpoint(options) {
   options = options || {};
-
-  this.hooks = [];
 
   this.defaults = {};
   if (!_.isEmpty(options.defaults)) {
@@ -136,17 +142,7 @@ Endpoint.create = function create(url, defaults, apis, verbs, name) {
     name: name,
     verbs: verbs
   });
-
-  apis[name].use(validateHeader);
-  apis[name].use(validateId);
-  apis[name].use(validateBody);
-
   return apis;
-};
-
-Endpoint.prototype.use = function use(fn) {
-  this.hooks.push(fn);
-  return this;
 };
 
 /**
@@ -191,9 +187,7 @@ _.each(['get', 'post', 'put', 'delete'], function makeMethods(method) {
       throw new Error('Unsupported method ' + method + ' for API ' + this.name);
     }
 
-    _.forEach(this.hooks, function (fn) {
-      options = fn(verb, options);
-    });
+    hooks.execPre('_createRequest', this, [verb, options]);
 
     options.method = method.toUpperCase();
     return this._createRequest(verb, options);

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,0 +1,75 @@
+/**
+ * @module hooks
+ * @desc Provides a generic pre/post hook implementation.
+ *
+ */
+
+/**
+ * Hooks constructor
+ *
+ * @constructor
+ */
+function Hooks() {
+  this._pres = {};
+  this._posts = {};
+}
+
+/**
+ * Execute all the registered pre hooks
+ *
+ * @param {string} name - the name of the function that is being hooked.
+ * @param {Object} context - a context object like `this`.
+ * @param {Array} args - a list of arguments to pass to the hook.
+ */
+Hooks.prototype.execPre = function(name, context, args) {
+  args = args || [];
+  var pres = this._pres[name] || [];
+  var numPres = pres.length;
+
+  for (var i = 0; i < numPres; ++i) {
+    pres[i].apply(context, args);
+  }
+};
+
+/**
+ * Execute all the registered post hooks
+ *
+ * @param {string} name - the name of the function that is being hooked.
+ * @param {Object} context - a context object like `this`.
+ * @param {Array} args - a list of arguments to pass to the hook.
+ */
+Hooks.prototype.execPost = function(name, context, args) {
+  args = args || [];
+  var posts = this._posts[name] || [];
+  var numPosts = posts.length;
+
+  for (var i = 0; i < numPosts; ++i) {
+    posts[i].apply(context, args);
+  }
+};
+
+/**
+ * Register a function to execute before the named function.
+ *
+ * @param {string} name - the name of the function that is being hooked.
+ * @param {function} fn - a function to execute before the named function.
+ * @return {Hooks} instance of Hooks
+ */
+Hooks.prototype.pre = function(name, fn) {
+  (this._pres[name] = this._pres[name] || []).push(fn);
+  return this;
+};
+
+/**
+ * Register a function to execute after the named function.
+ *
+ * @param {string} name - the name of the function that is being hooked.
+ * @param {function} fn - a function to execute after the named function.
+ * @return {Hooks} instance of Hooks
+ */
+Hooks.prototype.post = function(name, fn) {
+  (this._posts[name] = this._posts[name] || []).push(fn);
+  return this;
+};
+
+module.exports = Hooks;

--- a/tests/hooks.js
+++ b/tests/hooks.js
@@ -1,0 +1,107 @@
+require('./helpers').should;
+
+var
+  helpers = require('./helpers'),
+  chai = helpers.chai,
+  debuglog = helpers.debuglog,
+  Hooks = require('../lib/hooks');
+
+chai.use(helpers.cap);
+
+
+describe('hooks', function () {
+  var hooks;
+
+  before(function () {
+    hooks = new Hooks();
+  });
+
+  describe('#pre', function () {
+
+    it('successfully register pre hook', function () {
+        function preTrial() {
+          debuglog('function preTrial');
+        }
+        hooks.pre('trial', preTrial);
+        hooks._pres.should.have.property('trial');
+    });
+
+  });
+
+  describe('#execPre', function () {
+
+    it('successfully run execPre with no hooks', function () {
+      function shouldNotThrow() {
+        var otherHooks = new Hooks();
+        otherHooks.execPre('other', {});
+      }
+      shouldNotThrow.should.not.throw('any error');
+    });
+
+    it('successfully execute pre hook - without args', function () {
+        var value = null;
+        function testHook() {
+            value = 'success';
+        }
+        hooks.pre('testing', testHook);
+        hooks.execPre('testing', {});
+        value.should.be.equal('success');
+    });
+
+    it('successfully execute pre hook - with args', function () {
+        var value = null;
+        function testHook(data) {
+            value = data;
+        }
+        hooks.pre('testargs', testHook);
+        hooks.execPre('testargs', {}, ['arg-success']);
+        value.should.be.equal('arg-success');
+    });
+
+  });
+
+  describe('#post', function () {
+
+    it('successfully register post hook', function () {
+        function postTrial() {
+          debuglog('function postTrial');
+        }
+        hooks.post('trial', postTrial);
+        hooks._posts.should.have.property('trial');
+    });
+
+  });
+
+  describe('#execPost', function () {
+
+    it('successfully run execPost with no hooks', function () {
+      function shouldNotThrow() {
+        var otherHooks = new Hooks();
+        otherHooks.execPost('other', {});
+      }
+      shouldNotThrow.should.not.throw('any error');
+    });
+
+    it('successfully execute post hook - without args', function () {
+        var value = null;
+        function testHook() {
+            value = 'success';
+        }
+        hooks.post('testing', testHook);
+        hooks.execPost('testing', {});
+        value.should.be.equal('success');
+    });
+
+    it('successfully execute post hook - with args', function () {
+        var value = null;
+        function testHook(data) {
+            value = data;
+        }
+        hooks.post('testargs', testHook);
+        hooks.execPost('testargs', {}, ['arg-success']);
+        value.should.be.equal('arg-success');
+    });
+
+  });
+
+});


### PR DESCRIPTION
Creates generic hooks module to remove the management of the hooks from
the Endpoint, and allow Endpoint to simply define the actual required
hooks and then delegate back to hooks for execution.
