### PR TITLE
fix(seal): Require master key share to unseal

### DIFF
--- a/config/apis.yml
+++ b/config/apis.yml
@@ -27,6 +27,9 @@ v1:
         - name: "key"
           type: "string"
           required: true
+        - name: "reset"
+          type: "bool"
+          required: false
   "sys/mounts/:id":
     get:
       id: false

--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -1,5 +1,4 @@
 debug: DEBUG
-no_global_token: VAULT_NO_GLOBAL_TOKEN
 
 vault_host: VAULT_HOST
 vault_port: VAULT_PORT
@@ -21,4 +20,3 @@ proxy_password: VAULT_PROXY_PASSWORD
 timeout: VAULT_TIMEOUT
 secret_shares: SECRET_SHARES
 secret_threshold: SECRET_THRESHOLD
-backup_dir: VAULT_SAFE

--- a/config/default.yml
+++ b/config/default.yml
@@ -7,5 +7,3 @@ ssl_verify: true
 
 secret_shares: 3
 secret_threshold: 2
-
-no_global_token: false

--- a/docs/all_options.md
+++ b/docs/all_options.md
@@ -64,5 +64,3 @@ proxy_username | VAULT_PROXY_USERNAME |  | HTTP Proxy server username
 debug | DEBUG | `false` | Show verbose messages, network requests?
 secret_shares | SECRET_SHARES | `3` | Number of shared secret keys to generate
 secret_threshold | SECRET_THRESHOLD | `2` | Threshold at which to unseal vault (must be <= SECRET_SHARES)
-backup_dir | VAULT_SAFE | `~/.vault` | Directory to backup keys
-no_global_token | VAULT_NO_GLOBAL_TOKEN | `false` | Require token per API call

--- a/docs/config.md
+++ b/docs/config.md
@@ -25,4 +25,4 @@ Process the configurations using inputs and environment variables.
 <a name="ALL_OPTIONS"></a>
 ## ALL_OPTIONS : <code>Array</code>
 **Kind**: global constant  
-**Default**: <code>[&quot;debug&quot;,&quot;vault_host&quot;,&quot;vault_port&quot;,&quot;vault_ssl&quot;,&quot;vault_token&quot;,&quot;ssl_ciphers&quot;,&quot;ssl_cert_file&quot;,&quot;ssl_pem_file&quot;,&quot;ssl_pem_passphrase&quot;,&quot;ssl_ca_cert&quot;,&quot;ssl_verify&quot;,&quot;proxy_address&quot;,&quot;proxy_port&quot;,&quot;proxy_username&quot;,&quot;proxy_password&quot;,&quot;timeout&quot;,&quot;secret_shares&quot;,&quot;secret_threshold&quot;,&quot;backup_dir&quot;,&quot;no_global_token&quot;]</code>  
+**Default**: <code>[&quot;debug&quot;,&quot;vault_host&quot;,&quot;vault_port&quot;,&quot;vault_ssl&quot;,&quot;vault_token&quot;,&quot;ssl_ciphers&quot;,&quot;ssl_cert_file&quot;,&quot;ssl_pem_file&quot;,&quot;ssl_pem_passphrase&quot;,&quot;ssl_ca_cert&quot;,&quot;ssl_verify&quot;,&quot;proxy_address&quot;,&quot;proxy_port&quot;,&quot;proxy_username&quot;,&quot;proxy_password&quot;,&quot;timeout&quot;,&quot;secret_shares&quot;,&quot;secret_threshold&quot;]</code>  

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -9,37 +9,54 @@ var Vaulted = require('vaulted');
 
 var myVault = new Vaulted({
   vault_host: '127.0.0.1',
-  vault_port: 8200
+  vault_port: 8200,
+  vault_ssl: false
 });
 
-myVault.init()
+var keys;
+
+myVault.prepare()
   .bind(myVault)
-  .then(myVault.init)
-  .then(myVault.unSeal)
+  .then(function () {
+    return myVault.init();
+  }).then(function (data) {
+    myVault.setToken(data.root_token);
+    keys = data.keys;
+  })
+  .then(function () {
+    return myVault.unSeal({
+      body: {
+        key: keys[0]
+      }
+    });
+  })
+  .then(function () {
+    return myVault.unSeal({
+      body: {
+        key: keys[1]
+      }
+    });
+  })
   .then(function () {
     console.log('Vault is now ready!');
   })
   .catch(function onError(err) {
-    console.error('Could not initialize or unseal vault: %s', err.message);
+    console.error('Could not initialize or unseal vault:', err.message, err.error);
   });
 ```
 
-By default the token and keys are in a backup file located in the directory specified by the value of `backup_dir`.
 
 ## Existing Vault
-
-When working with an existing Vault the basic flow depends on if the backup file exists or not.
 
 ```javascript
 var Vaulted = require('vaulted');
 
 var myVault = new Vaulted({
   vault_host: '127.0.0.1',
-  vault_port: 8200
+  vault_port: 8200,
+  vault_ssl: false
 });
 
-// without backup file this step is required otherwise
-// the step below is all that is required.
 myVault.setToken('mytoken');
 
 myVault.prepare()

--- a/docs/internal.md
+++ b/docs/internal.md
@@ -1,22 +1,4 @@
-## Modules
-
-<dl>
-<dt><a href="#module_internal">internal</a></dt>
-<dd><p>Provides backup and recovery of master token and keys for the Vault.</p>
-</dd>
-</dl>
-
-## Constants
-
-<dl>
-<dt><a href="#DEFAULT_BACKUP_DIR">DEFAULT_BACKUP_DIR</a> : <code>string</code></dt>
-<dd></dd>
-</dl>
-
 <a name="module_internal"></a>
 ## internal
-Provides backup and recovery of master token and keys for the Vault.
+Provides internal helpers for working with the Vault.
 
-<a name="DEFAULT_BACKUP_DIR"></a>
-## DEFAULT_BACKUP_DIR : <code>string</code>
-**Kind**: global constant  

--- a/docs/sys/init.md
+++ b/docs/sys/init.md
@@ -13,7 +13,7 @@ Provides implementation for the Vault Initialization APIs
 Initializes a remote vault
 
 **Kind**: inner method of <code>[init](#module_init)</code>  
-**Resolve**: <code>Vaulted</code> Resolves with current instance of Vaulted after capturing the keys and token  
+**Resolve**: <code>Vaulted</code> Resolves with keys and token or current instance of Vaulted  
 **Reject**: <code>Error</code> An error indicating what went wrong  
 
 | Param | Type | Default | Description |

--- a/docs/sys/keys.md
+++ b/docs/sys/keys.md
@@ -91,4 +91,6 @@ Sends the next key share to continue the rekey process.
 | --- | --- | --- |
 | [options] | <code>Object</code> | object of options to send to API request |
 | [options.token] | <code>string</code> | the authentication token |
+| options.body | <code>Object</code> | holds the attributes passed as inputs |
+| options.body.key | <code>Object</code> | A single master share key |
 

--- a/docs/sys/seal.md
+++ b/docs/sys/seal.md
@@ -7,7 +7,7 @@ Provides implementation for the Vault Seal APIs
 * [seal](#module_seal) ⇐ <code>Vaulted</code>
     * [~getSealedStatus()](#module_seal..getSealedStatus) ⇒ <code>Promise</code>
     * [~seal([options])](#module_seal..seal) ⇒ <code>Promise</code>
-    * [~unSeal()](#module_seal..unSeal) ⇒ <code>Promise</code>
+    * [~unSeal(options)](#module_seal..unSeal) ⇒ <code>Promise</code>
 
 <a name="module_seal..getSealedStatus"></a>
 ### seal~getSealedStatus() ⇒ <code>Promise</code>
@@ -30,9 +30,17 @@ Seals the vault
 | [options.token] | <code>string</code> | the authentication token |
 
 <a name="module_seal..unSeal"></a>
-### seal~unSeal() ⇒ <code>Promise</code>
+### seal~unSeal(options) ⇒ <code>Promise</code>
 Unseals the vault
 
 **Kind**: inner method of <code>[seal](#module_seal)</code>  
 **Resolve**: <code>Vaulted</code> Resolves with current instance of Vaulted  
 **Reject**: <code>Error</code> An error indicating what went wrong  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options | <code>Object</code> | object of options to send to API request |
+| options.body | <code>Object</code> | holds the attributes passed as inputs |
+| options.body.key | <code>Object</code> | A single master share key |
+| [options.body.reset] | <code>Object</code> | if true, the previously-provided unseal keys are discarded from memory and the unseal process is reset. |
+

--- a/docs/vaulted.md
+++ b/docs/vaulted.md
@@ -11,14 +11,12 @@ Vaulted is a nodejs-based wrapper for the Vault HTTP API.
         * [.api](#module_vaulted..Vaulted+api) : <code>API</code>
         * [.status](#module_vaulted..Vaulted+status) : <code>Object</code>
         * [.token](#module_vaulted..Vaulted+token) : <code>string</code>
-        * [.keys](#module_vaulted..Vaulted+keys) : <code>Array</code>
         * [.auths](#module_vaulted..Vaulted+auths) : <code>Object</code>
         * [.mounts](#module_vaulted..Vaulted+mounts) : <code>Object</code>
         * [.headers](#module_vaulted..Vaulted+headers) : <code>Object</code>
         * [.initialized](#module_vaulted..Vaulted+initialized) : <code>boolean</code>
     * [~prepare()](#module_vaulted..prepare) ⇒ <code>Promise</code>
     * [~setToken(vault_token)](#module_vaulted..setToken) ⇒ <code>Vaulted</code>
-    * [~setKeys(keys)](#module_vaulted..setKeys) ⇒ <code>Vaulted</code>
     * [~setStatus(status)](#module_vaulted..setStatus) ⇒ <code>Vaulted</code>
     * [~validateEndpoint(endpoint, [mountName], [defaultName])](#module_vaulted..validateEndpoint) ⇒ <code>EndPoint</code>
 
@@ -32,7 +30,6 @@ Vaulted is a nodejs-based wrapper for the Vault HTTP API.
     * [.api](#module_vaulted..Vaulted+api) : <code>API</code>
     * [.status](#module_vaulted..Vaulted+status) : <code>Object</code>
     * [.token](#module_vaulted..Vaulted+token) : <code>string</code>
-    * [.keys](#module_vaulted..Vaulted+keys) : <code>Array</code>
     * [.auths](#module_vaulted..Vaulted+auths) : <code>Object</code>
     * [.mounts](#module_vaulted..Vaulted+mounts) : <code>Object</code>
     * [.headers](#module_vaulted..Vaulted+headers) : <code>Object</code>
@@ -58,9 +55,6 @@ Vaulted constructor
 **Kind**: instance property of <code>[Vaulted](#module_vaulted..Vaulted)</code>  
 <a name="module_vaulted..Vaulted+token"></a>
 #### vaulted.token : <code>string</code>
-**Kind**: instance property of <code>[Vaulted](#module_vaulted..Vaulted)</code>  
-<a name="module_vaulted..Vaulted+keys"></a>
-#### vaulted.keys : <code>Array</code>
 **Kind**: instance property of <code>[Vaulted](#module_vaulted..Vaulted)</code>  
 <a name="module_vaulted..Vaulted+auths"></a>
 #### vaulted.auths : <code>Object</code>
@@ -96,21 +90,6 @@ also sets the 'X-Vault-Token' header with token value
 | Param | Type | Description |
 | --- | --- | --- |
 | vault_token | <code>String</code> | the root/master token |
-
-<a name="module_vaulted..setKeys"></a>
-### vaulted~setKeys(keys) ⇒ <code>Vaulted</code>
-Sets the keys to use when sealing and unsealing the vault.
-
-**Kind**: inner method of <code>[vaulted](#module_vaulted)</code>  
-**Returns**: <code>Vaulted</code> - instance of Vaulted  
-**Throws**:
-
-- <code>Error</code> - Vault keys not provided, or is empty list.
-
-
-| Param | Type | Description |
-| --- | --- | --- |
-| keys | <code>Array</code> | shares of the master key |
 
 <a name="module_vaulted..setStatus"></a>
 ### vaulted~setStatus(status) ⇒ <code>Vaulted</code>

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,9 +1,5 @@
 'use strict';
-// a bit of a hack but it seems that NPM does not seem to install
-// the provided configurations in the application root.
-if (!require('./utils').configured()) {
-  process.env.NODE_CONFIG_DIR = __dirname + '/../config';
-}
+process.env.SUPPRESS_NO_CONFIG_WARNING = 'y';
 var
   _ = require('lodash'),
   config = require('config');
@@ -30,10 +26,18 @@ var ALL_OPTIONS = [
   'proxy_password',
   'timeout',
   'secret_shares',
-  'secret_threshold',
-  'backup_dir',
-  'no_global_token'
+  'secret_threshold'
 ];
+
+var DEFAULTS = {
+  vault_host: '127.0.0.1',
+  vault_port: 8200,
+  vault_ssl: true,
+  ssl_ciphers: 'TLSv1.2',
+  ssl_verify: true,
+  secret_shares: 3,
+  secret_threshold: 2
+};
 
 /**
  * @module config
@@ -44,7 +48,7 @@ var ALL_OPTIONS = [
 /** Process the configurations using inputs and environment variables. */
 
 module.exports = function validate(options) {
-  options = options || {};
+  options = _.defaults(options || {}, DEFAULTS);
 
   var invalids = [];
   var check = _.partial(_.includes, ALL_OPTIONS);

--- a/lib/internal.js
+++ b/lib/internal.js
@@ -1,30 +1,20 @@
 'use strict';
 var
   _ = require('lodash'),
-  Promise = require('bluebird'),
-  mkdirp = Promise.promisifyAll(require('mkdirp')),
-  fs = Promise.promisifyAll(require('fs')),
-  path = require('path'),
-  os = require('os'),
   debuglog = require('util').debuglog('vaulted');
 
-/** @constant
-    @type {string}
-    @default
-*/
-var DEFAULT_BACKUP_DIR = path.join(os.homedir(), '.vault');
 
 /**
   * @module internal
-  * @desc Provides backup and recovery of master token and keys for the Vault.
+  * @desc Provides internal helpers for working with the Vault.
   *
  */
 
 var internal = module.exports;
 
 function checkStatus(vault, status) {
-  if (!status.initialized || !_.isArray(vault.keys) || vault.keys.length === 0) {
-    debuglog('either vault not initialized or no keys found');
+  if (!status.initialized) {
+    debuglog('either vault not initialized');
     return vault;
   }
   return vault.getSealedStatus().bind(vault)
@@ -40,7 +30,6 @@ function checkStatus(vault, status) {
     });
 }
 
-
 /**
  * @private
  * @method loadState
@@ -52,89 +41,8 @@ function checkStatus(vault, status) {
  * @return {Promise}
  */
 internal.loadState = function loadState(vault) {
-  return this.recover(vault).bind(vault)
-    .then(vault.getInitStatus)
+  return vault.getInitStatus().bind(vault)
     .then(_.partial(checkStatus, vault));
-};
-
-function getBackupDir(vault) {
-  var dirname = DEFAULT_BACKUP_DIR;
-  if (vault.config.has('backup_dir')) {
-    dirname = vault.config.get('backup_dir');
-  }
-  return dirname;
-}
-
-function getBackupFile(vault) {
-  return path.join(getBackupDir(vault), 'keys.json');
-}
-
-/**
- * @private
- * @method backup
- * @desc Save the internal state to a file.
- *
- * @param {Vaulted} vault an instance of Vaulted.
- * @resolve {Vaulted} Resolves with current instance of Vaulted
- * @reject {Error} An error indicating what went wrong
- * @return {Promise}
- */
-internal.backup = function backup(vault) {
-  var backupFile = getBackupFile(vault);
-  var ownmode = {mode: parseInt('0700', 8)};
-  var data = JSON.stringify({root: vault.token, keys: vault.keys});
-
-  if (!_.isString(vault.token) || !_.isArray(vault.keys) || vault.keys.length === 0) {
-    debuglog('no data to backup');
-    return Promise.resolve(vault);
-  }
-
-  return mkdirp.mkdirpAsync(getBackupDir(vault), ownmode).then(function () {
-    return fs.writeFileAsync(backupFile, data, ownmode).then(function () {
-      debuglog('backup file written');
-      return vault;
-    });
-  }).catch(function (err) {
-    debuglog('failed to save keys: %s', err.message);
-    return vault;
-  });
-};
-
-/**
- * @private
- * @method recover
- * @desc Retrieve the internal state from backup file.
- *
- * @param {Vaulted} vault an instance of Vaulted.
- * @resolve {Vaulted} Resolves with current instance of Vaulted
- * @reject {Error} An error indicating what went wrong
- * @return {Promise}
- */
-internal.recover = function recover(vault) {
-  var backupFile = getBackupFile(vault);
-
-  return fs.readFileAsync(backupFile)
-  .then(JSON.parse)
-  .then(function (data) {
-    if (_.isString(data.root) && _.isArray(data.keys) && data.keys.length > 0) {
-      vault.setToken(data.root);
-      vault.setKeys(data.keys);
-      debuglog('recover successful');
-    }
-    return vault;
-  })
-  .catch(SyntaxError, function (err) {
-    // invalid file (someone been modifying it?)
-    debuglog('failed to recover backup: %s', err.message);
-    return vault;
-  })
-  .catch(function (err) {
-    // file most likely does not exist so just ignore it.
-    if (err.code !== 'ENOENT') {
-      debuglog('unable to read backup: %s', err.message);
-    }
-    return vault;
-  });
 };
 
 /**

--- a/lib/listeners.js
+++ b/lib/listeners.js
@@ -18,10 +18,6 @@ module.exports = function extend(Proto) {
 Vaulted.enableListeners = function enableListeners() {
   var self = this;
 
-  self.on('init', function () {
-    internal.backup(self);
-  });
-
   self.on('unsealed', function () {
     internal.loadState(self).then(function () {
       internal.syncMounts(self);

--- a/lib/sys/init.js
+++ b/lib/sys/init.js
@@ -22,7 +22,7 @@ module.exports = function extend(Proto) {
  * @param {Object} options - object of options to send to API request
  * @param {number} [options.secret_shares=config['secret_shares']] - number of shares to split the master key into
  * @param {number} [options.secret_threshold=config['secret_threshold']] - number of shares required to reconstruct the master key
- * @resolve {Vaulted} Resolves with current instance of Vaulted after capturing the keys and token
+ * @resolve {Vaulted} Resolves with keys and token or current instance of Vaulted
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
  */
@@ -39,14 +39,6 @@ Vaulted.init = Promise.method(function init(options) {
   return this.api.getEndpoint('sys/init')
     .put({
       body: options
-    })
-    .promise()
-    .bind(this)
-    .then(function keysAndToken(keys_and_token) {
-      this.setKeys(keys_and_token.keys);
-      this.setToken(keys_and_token.root_token);
-      this.emit('init');
-      return this;
     });
 });
 

--- a/lib/sys/keys.js
+++ b/lib/sys/keys.js
@@ -3,7 +3,7 @@ var
   Vaulted = {},
   Promise = require('bluebird'),
   _ = require('lodash'),
-  internal = require('../internal');
+  utils = require('../utils');
 
 /**
   * @module keys
@@ -133,29 +133,20 @@ Vaulted.stopRekey = Promise.method(function stopRekey(options) {
  *
  * @param {Object} [options] - object of options to send to API request
  * @param {string} [options.token] - the authentication token
+ * @param {Object} options.body - holds the attributes passed as inputs
+ * @param {Object} options.body.key - A single master share key
  * @resolve {Vaulted} Resolves with current instance of Vaulted after capturing the keys and token
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
  */
 Vaulted.updateRekey = Promise.method(function updateRekey(options) {
-  options = options || {};
+  options = utils.setDefaults(options);
 
   return this.getRekeyUpdateEndpoint()
     .put({
       headers: this.headers,
-      body: {
-        key: _.sample(this.keys)
-      },
+      body: options.body,
       _token: options.token
-    })
-    .promise()
-    .bind(this)
-    .then(function rekeyDone(status) {
-      if (status.complete) {
-        this.setKeys(status.keys);
-        return internal.backup(this);
-      }
-      return this.updateRekey(options);
     });
 
 });

--- a/lib/sys/seal.js
+++ b/lib/sys/seal.js
@@ -2,7 +2,8 @@
 var
   Vaulted = {},
   Promise = require('bluebird'),
-  _ = require('lodash');
+  _ = require('lodash'),
+  utils = require('../utils');
 
 /**
   * @module seal
@@ -64,11 +65,18 @@ Vaulted.seal = Promise.method(function(options) {
  * @method unSeal
  * @desc Unseals the vault
  *
+ * @param {Object} options - object of options to send to API request
+ * @param {Object} options.body - holds the attributes passed as inputs
+ * @param {Object} options.body.key - A single master share key
+ * @param {Object} [options.body.reset] - if true, the previously-provided unseal
+ * keys are discarded from memory and the unseal process is reset.
  * @resolve {Vaulted} Resolves with current instance of Vaulted
  * @reject {Error} An error indicating what went wrong
  * @return {Promise}
  */
-Vaulted.unSeal = Promise.method(function unSeal() {
+Vaulted.unSeal = Promise.method(function unSeal(options) {
+  options = utils.setDefaults(options);
+
   if (!this.initialized) {
     return Promise.reject(new Error('Vault has not been initialized.'));
   }
@@ -76,14 +84,12 @@ Vaulted.unSeal = Promise.method(function unSeal() {
     this.emit('unsealed');
     return Promise.resolve(this);
   }
+
   return this.api.getEndpoint('sys/unseal')
     .put({
-      body: {
-        key: _.sample(this.keys)
-      }
+      body: options.body
     })
     .promise()
     .bind(this)
-    .then(this.setStatus)
-    .then(this.unSeal);
+    .then(this.setStatus);
 });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,19 +1,9 @@
 'use strict';
 var
-  _ = require('lodash'),
-  fs = require('fs');
+  _ = require('lodash');
 
 
 var utils = module.exports;
-
-function fileExists(location) {
-  try {
-    fs.statSync(location);
-    return true;
-  } catch (err) {
-    return false;
-  }
-}
 
 utils.setDefaults = function setDefaults(options, defaults) {
   options = _.isPlainObject(options) ? options : {};
@@ -23,17 +13,4 @@ utils.setDefaults = function setDefaults(options, defaults) {
   }
   options.body = _.defaults(options.body, defaults);
   return options;
-};
-
-utils.configured = function configured() {
-  var flag = false;
-
-  if (process.env.NODE_CONFIG_DIR) {
-    flag = true;
-  }
-
-  if (fileExists(process.cwd() + '/config')) {
-    flag = true;
-  }
-  return flag;
 };

--- a/lib/vaulted.js
+++ b/lib/vaulted.js
@@ -33,8 +33,6 @@ function Vaulted(options) {
   };
   /** @member {string} */
   this.token = null;
-  /** @member {Array} */
-  this.keys = [];
   /** @member {Object} */
   this.auths = {};
   /** @member {Object} */
@@ -78,30 +76,13 @@ Vaulted.prototype.setToken = function setToken(vault_token) {
   if (!_.isString(vault_token) || vault_token.length === 0) {
     throw new Error('Vault token not provided, or has zero-length.');
   }
-  if (!this.config.has('no_global_token') || this.config.get('no_global_token') !== true) {
-    this.token = vault_token;
-    this.headers = {
-      'X-Vault-Token': this.token
-    };
-  }
+  this.token = vault_token;
+  this.headers = {
+    'X-Vault-Token': this.token
+  };
+
   // having token means being initialized
   this.initialized = true;
-  return this;
-};
-
-/**
- * @method setKeys
- * @desc Sets the keys to use when sealing and unsealing the vault.
- *
- * @param {Array} keys - shares of the master key
- * @returns {Vaulted} instance of Vaulted
- * @throws {Error} - Vault keys not provided, or is empty list.
- */
-Vaulted.prototype.setKeys = function setKeys(keys) {
-  if (!_.isArray(keys) || keys.length === 0) {
-    throw new Error('Vault keys not provided, or is empty list.');
-  }
-  this.keys = keys;
   return this;
 };
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "lodash": "^3.10.0",
     "request-promise": "^1.0.2",
     "request-debug": "^0.2.0",
-    "mkdirp": "^0.5.1",
     "js-yaml": "^3.4.6"
   },
   "devDependencies": {

--- a/tests/_init.js
+++ b/tests/_init.js
@@ -5,8 +5,7 @@ var
   helpers = require('./helpers'),
   debuglog = helpers.debuglog,
   chai = helpers.chai,
-  assert = helpers.assert,
-  Vault = require('../lib/vaulted');
+  assert = helpers.assert;
 
 chai.use(helpers.cap);
 
@@ -20,27 +19,28 @@ describe('init', function() {
     });
   });
 
-  it.skip('initialized false', function () {
+  it('initialized false', function () {
     return myVault.getInitStatus().then(function (result) {
         result.initialized.should.be.false;
     });
   });
 
   it('init successful', function () {
-    return myVault.init().then(function (self) {
-        self.should.be.an.instanceof(Vault);
-        self.initialized.should.be.true;
-        self.token.should.not.be.null;
-        self.keys.should.not.be.empty;
+    return myVault.init().then(function (data) {
+      assert.ok(data, 'token and keys should be returned');
+      data.should.have.property('root_token');
+      data.root_token.should.be.a('string');
+      data.should.have.property('keys');
+      data.keys.should.be.a('array');
+      myVault.setToken(data.root_token);
+      helpers.backup(data);
     });
   });
 
   it('init - already initialized', function () {
     return myVault.init().then(function (self) {
-        self.should.be.an.instanceof(Vault);
         self.initialized.should.be.true;
         self.token.should.not.be.null;
-        self.keys.should.not.be.empty;
     });
   });
 

--- a/tests/_unseal.js
+++ b/tests/_unseal.js
@@ -13,10 +13,12 @@ chai.use(helpers.cap);
 describe('seal', function () {
   var newVault = helpers.getEmptyVault();
   var myVault;
+  var myKeys;
 
   before(function () {
     return helpers.getPreparedVault().then(function (vault) {
       myVault = vault;
+      myKeys = helpers.recover().keys;
     });
   });
 
@@ -33,8 +35,15 @@ describe('seal', function () {
 
   describe('#unSeal', function () {
 
-    it('should resolve to binded instance - success', function () {
-      return myVault.unSeal().then(function (self) {
+    it('should resolve to binded instance - success still sealed', function () {
+      return myVault.unSeal({body: {key: myKeys[0]}}).then(function (self) {
+        self.status.should.have.property('sealed');
+        self.status.sealed.should.be.true;
+      });
+    });
+
+    it('should resolve to binded instance - success unsealed', function () {
+      return myVault.unSeal({body: {key: myKeys[1]}}).then(function (self) {
         self.status.should.have.property('sealed');
         self.status.sealed.should.be.false;
       });
@@ -84,7 +93,7 @@ describe('seal', function () {
 
   after(function (done) {
     this.timeout(5000);
-    helpers.isVaultReady(myVault).then(function (status) {
+    helpers.isVaultReady(myVault).then(function () {
       done();
     }).catch(function onError(err) {
       debuglog('Vault NOT Ready: ', err);

--- a/tests/api.js
+++ b/tests/api.js
@@ -2,7 +2,6 @@
 require('./helpers').should;
 
 var
-  _ = require('lodash'),
   fs = require('fs'),
   path = require('path'),
   helpers = require('./helpers'),
@@ -138,8 +137,8 @@ describe('API', function() {
       api.should.exist;
       api.endpoints.should.include.keys('auth/token/create');
       api.endpoints['auth/token/create'].should.include.keys('defaults');
-      api.endpoints['auth/token/create']['defaults'].should.include.keys('proxy');
-      api.endpoints['auth/token/create']['defaults']['proxy'].should.be.equal('https://abc.example.com:443');
+      api.endpoints['auth/token/create'].defaults.should.include.keys('proxy');
+      api.endpoints['auth/token/create'].defaults.proxy.should.be.equal('https://abc.example.com:443');
     });
 
     it('with proxy configuration - insecure', function () {
@@ -153,8 +152,8 @@ describe('API', function() {
       api.should.exist;
       api.endpoints.should.include.keys('auth/token/create');
       api.endpoints['auth/token/create'].should.include.keys('defaults');
-      api.endpoints['auth/token/create']['defaults'].should.include.keys('proxy');
-      api.endpoints['auth/token/create']['defaults']['proxy'].should.be.equal('http://abc.example.com:8000');
+      api.endpoints['auth/token/create'].defaults.should.include.keys('proxy');
+      api.endpoints['auth/token/create'].defaults.proxy.should.be.equal('http://abc.example.com:8000');
     });
 
     it('with proxy configuration - with auth', function () {
@@ -170,8 +169,8 @@ describe('API', function() {
       api.should.exist;
       api.endpoints.should.include.keys('auth/token/create');
       api.endpoints['auth/token/create'].should.include.keys('defaults');
-      api.endpoints['auth/token/create']['defaults'].should.include.keys('proxy');
-      api.endpoints['auth/token/create']['defaults']['proxy'].should.be.equal('https://dummy:pass@abc.example.com:443');
+      api.endpoints['auth/token/create'].defaults.should.include.keys('proxy');
+      api.endpoints['auth/token/create'].defaults.proxy.should.be.equal('https://dummy:pass@abc.example.com:443');
     });
 
     it('with ssl configuration - cacert', function () {
@@ -184,8 +183,8 @@ describe('API', function() {
       api.should.exist;
       api.endpoints.should.include.keys('auth/token/create');
       api.endpoints['auth/token/create'].should.include.keys('defaults');
-      api.endpoints['auth/token/create']['defaults'].should.include.keys('ca');
-      api.endpoints['auth/token/create']['defaults']['ca'].should.be.eql(cacert);
+      api.endpoints['auth/token/create'].defaults.should.include.keys('ca');
+      api.endpoints['auth/token/create'].defaults.ca.should.be.eql(cacert);
     });
 
     it('with ssl configuration - cert and key', function () {
@@ -200,10 +199,10 @@ describe('API', function() {
       api.should.exist;
       api.endpoints.should.include.keys('auth/token/create');
       api.endpoints['auth/token/create'].should.include.keys('defaults');
-      api.endpoints['auth/token/create']['defaults'].should.include.keys('cert');
-      api.endpoints['auth/token/create']['defaults']['cert'].should.be.eql(clientcert);
-      api.endpoints['auth/token/create']['defaults'].should.include.keys('key');
-      api.endpoints['auth/token/create']['defaults']['key'].should.be.eql(clientkey);
+      api.endpoints['auth/token/create'].defaults.should.include.keys('cert');
+      api.endpoints['auth/token/create'].defaults.cert.should.be.eql(clientcert);
+      api.endpoints['auth/token/create'].defaults.should.include.keys('key');
+      api.endpoints['auth/token/create'].defaults.key.should.be.eql(clientkey);
     });
 
     it('with ssl configuration  - cert and key with passphrase', function () {
@@ -219,12 +218,12 @@ describe('API', function() {
       api.should.exist;
       api.endpoints.should.include.keys('auth/token/create');
       api.endpoints['auth/token/create'].should.include.keys('defaults');
-      api.endpoints['auth/token/create']['defaults'].should.include.keys('cert');
-      api.endpoints['auth/token/create']['defaults']['cert'].should.be.eql(clientcert);
-      api.endpoints['auth/token/create']['defaults'].should.include.keys('key');
-      api.endpoints['auth/token/create']['defaults']['key'].should.be.eql(clientkey);
-      api.endpoints['auth/token/create']['defaults'].should.include.keys('passphrase');
-      api.endpoints['auth/token/create']['defaults']['passphrase'].should.be.equal('fakephrase');
+      api.endpoints['auth/token/create'].defaults.should.include.keys('cert');
+      api.endpoints['auth/token/create'].defaults.cert.should.be.eql(clientcert);
+      api.endpoints['auth/token/create'].defaults.should.include.keys('key');
+      api.endpoints['auth/token/create'].defaults.key.should.be.eql(clientkey);
+      api.endpoints['auth/token/create'].defaults.should.include.keys('passphrase');
+      api.endpoints['auth/token/create'].defaults.passphrase.should.be.equal('fakephrase');
     });
 
     it('with timeout specified', function () {
@@ -236,8 +235,8 @@ describe('API', function() {
       api.should.exist;
       api.endpoints.should.include.keys('auth/token/create');
       api.endpoints['auth/token/create'].should.include.keys('defaults');
-      api.endpoints['auth/token/create']['defaults'].should.include.keys('timeout');
-      api.endpoints['auth/token/create']['defaults']['timeout'].should.be.equal(10);
+      api.endpoints['auth/token/create'].defaults.should.include.keys('timeout');
+      api.endpoints['auth/token/create'].defaults.timeout.should.be.equal(10);
     });
 
     afterEach(function () {
@@ -251,7 +250,7 @@ describe('API', function() {
         ssl_pem_passphrase: undefined,
         timeout: undefined
       };
-      config = config.util.extendDeep(myconfig, options);;
+      config = config.util.extendDeep(myconfig, options);
     });
 
   });

--- a/tests/endpoint.js
+++ b/tests/endpoint.js
@@ -73,7 +73,7 @@ describe('Endpoint', function () {
     var endpoint;
 
     beforeEach(function () {
-      endpoint = Endpoint.create(BASE_URL, {}, {}, api_def.punts, 'punts')['punts'];
+      endpoint = Endpoint.create(BASE_URL, {}, {}, api_def.punts, 'punts').punts;
     });
 
     it('should have a get method', function () {

--- a/tests/internal.js
+++ b/tests/internal.js
@@ -2,248 +2,13 @@
 require('./helpers').should;
 
 var
-  fs = require('fs'),
-  os = require('os'),
-  path = require('path'),
   helpers = require('./helpers'),
   debuglog = helpers.debuglog,
-  chai = helpers.chai,
-  assert = helpers.assert,
   expect = helpers.expect,
   internal = require('../lib/internal');
 
-chai.use(helpers.cap);
-
-var BACKUP_DIR = path.join(os.homedir(), '.vault');
-var BACKUP_FILE = path.join(BACKUP_DIR, 'keys.json');
-
-var renameFile = function (oldname, newname) {
-  try {
-    fs.renameSync(path.join(BACKUP_DIR, oldname), path.join(BACKUP_DIR, newname));
-  } catch (err) {
-    debuglog('failed to rename %s to %s: %s', oldname, newname, err);
-  }
-};
-
-var initOrRename = function (vault) {
-  return vault.getInitStatus().then(function (result) {
-    debuglog('initOrRename result status: %s', result.initialized);
-    if (!result.initialized) {
-      return vault.init();
-    } else {
-      renameFile('prev-keys.json', 'keys.json');
-      return internal.recover(vault);
-    }
-  });
-
-};
-
 
 describe('internal state', function () {
-  var myVault = helpers.getVault();
-
-  describe('#loadState', function () {
-
-    it('not initialized', function () {
-      renameFile('keys.json', 'prev-keys.json');
-      return internal.loadState(myVault).then(function (self) {
-        self.initialized.should.be.false;
-        myVault.initialized.should.be.false;
-        self.keys.should.be.empty;
-        myVault.keys.should.be.empty;
-      });
-    });
-
-    it('initialized', function () {
-      return initOrRename(myVault).then(function () {
-        return internal.loadState(myVault).then(function (self) {
-          self.initialized.should.be.true;
-          myVault.initialized.should.be.true;
-        });
-      });
-    });
-
-    it('unsealed', function () {
-      return myVault.unSeal().then(function () {
-        return internal.loadState(myVault).then(function (self) {
-          self.initialized.should.be.true;
-          myVault.initialized.should.be.true;
-          self.status.sealed.should.be.false;
-          myVault.status.sealed.should.be.false;
-        });
-      });
-    });
-
-    it('default mounts only', function () {
-      return internal.loadState(myVault).then(function (self) {
-        self.initialized.should.be.true;
-        myVault.initialized.should.be.true;
-        self.status.sealed.should.be.false;
-        myVault.status.sealed.should.be.false;
-        self.mounts.should.not.be.empty;
-        myVault.mounts.should.not.be.empty;
-        self.mounts.should.contain.keys('sys/');
-        myVault.mounts.should.contain.keys('sys/');
-      });
-    });
-
-    it('consul mounted', function () {
-      return myVault.mountConsul().then(function () {
-        return internal.loadState(myVault).then(function (self) {
-          self.initialized.should.be.true;
-          myVault.initialized.should.be.true;
-          self.status.sealed.should.be.false;
-          myVault.status.sealed.should.be.false;
-          self.mounts.should.not.be.empty;
-          myVault.mounts.should.not.be.empty;
-          self.mounts.should.contain.keys('consul/');
-          myVault.mounts.should.contain.keys('consul/');
-        });
-      });
-    });
-
-    it('initialized with no backup', function () {
-      renameFile('keys.json', 'prev-keys.json');
-      myVault.keys = [];
-      return internal.loadState(myVault).then(function (self) {
-        self.initialized.should.be.true;
-        myVault.initialized.should.be.true;
-        self.keys.should.be.empty;
-        myVault.keys.should.be.empty;
-      });
-    });
-
-  });
-
-  describe('#backup', function () {
-
-    it('no data', function () {
-      myVault.token = null;
-      myVault.keys = [];
-      return internal.backup(myVault).then(function () {
-        try {
-          var stats = fs.statSync(BACKUP_FILE);
-          assert.notOk(stats, 'file should not exist');
-        } catch (err) {
-          err.should.be.an.instanceof(Error);
-          err.code.should.equal('ENOENT');
-        }
-      });
-    });
-
-    it('keys not Array', function () {
-      myVault.keys = null;
-      return internal.backup(myVault).then(function () {
-        try {
-          var stats = fs.statSync(BACKUP_FILE);
-          assert.notOk(stats, 'file should not exist');
-        } catch (err) {
-          err.should.be.an.instanceof(Error);
-          err.code.should.equal('ENOENT');
-        }
-        myVault.keys = [];
-      });
-    });
-
-    it('keys empty Array', function () {
-      return internal.backup(myVault).then(function () {
-        try {
-          var stats = fs.statSync(BACKUP_FILE);
-          assert.notOk(stats, 'file should not exist');
-        } catch (err) {
-          err.should.be.an.instanceof(Error);
-          err.code.should.equal('ENOENT');
-        }
-      });
-    });
-
-    it('success', function () {
-      return initOrRename(myVault).then(function () {
-        return internal.backup(myVault).then(function () {
-          try {
-            var stats = fs.statSync(BACKUP_FILE);
-            debuglog(stats);
-            debuglog(stats.isFile());
-            stats.isFile().should.be.true;
-          } catch (err) {
-            debuglog(err);
-            assert.notOk(err, 'backup file failed for some reason');
-          }
-        });
-      });
-    });
-
-  });
-
-  describe('#recover', function () {
-
-    it('no file', function () {
-      myVault.config = myVault.config.util.extendDeep(myVault.config, {
-        backup_dir: BACKUP_DIR
-      });
-      renameFile('keys.json', 'prev-keys.json');
-      myVault.token = null;
-      myVault.keys = [];
-      return internal.recover(myVault).then(function () {
-        expect(myVault.token).to.be.null;
-        expect(myVault.keys).to.be.empty;
-      });
-    });
-
-    it('invalid file data', function () {
-      var data = '{"root"}';
-      fs.writeFileSync(BACKUP_FILE, data);
-      return internal.recover(myVault).then(function () {
-        expect(myVault.token).to.be.null;
-        expect(myVault.keys).to.be.empty;
-      });
-    });
-
-    it('no root token', function () {
-      var data = JSON.stringify({
-        'keys': []
-      });
-      fs.writeFileSync(BACKUP_FILE, data);
-      return internal.recover(myVault).then(function () {
-        expect(myVault.token).to.be.null;
-        expect(myVault.keys).to.be.empty;
-      });
-    });
-
-    it('keys not Array', function () {
-      var data = JSON.stringify({
-        'root': 'xyz',
-        'keys': 'abc,xyz'
-      });
-      fs.writeFileSync(BACKUP_FILE, data);
-      return internal.recover(myVault).then(function () {
-        expect(myVault.token).to.be.null;
-        expect(myVault.keys).to.be.empty;
-      });
-    });
-
-    it('keys empty Array', function () {
-      var data = JSON.stringify({
-        'root': 'xyz',
-        'keys': []
-      });
-      fs.writeFileSync(BACKUP_FILE, data);
-      return internal.recover(myVault).then(function () {
-        expect(myVault.token).to.be.null;
-        expect(myVault.keys).to.be.empty;
-      });
-    });
-
-    it('success', function () {
-      fs.unlinkSync(BACKUP_FILE);
-      renameFile('prev-keys.json', 'keys.json');
-      return internal.recover(myVault).then(function () {
-        expect(myVault.token).to.not.be.null;
-        expect(myVault.keys).to.not.be.empty;
-      });
-    });
-
-  });
 
   describe('#syncMounts', function () {
     var aVault;
@@ -272,6 +37,7 @@ describe('internal state', function () {
       expect(aVault.api.endpoints['myCon/config/access']).to.be.undefined;
       expect(aVault.api.endpoints['auth/myApp/login']).to.be.undefined;
       internal.syncMounts(aVault);
+      debuglog('syncMounts completed');
       // return Promise.delay(500).then(function () {
       //   expect(aVault.api.endpoints['myCon/config/access']).to.not.be.undefined;
       //   expect(aVault.api.endpoints['auth/myApp/login']).to.not.be.undefined;
@@ -289,12 +55,6 @@ describe('internal state', function () {
 
     });
 
-  });
-
-  after(function () {
-    return myVault.deleteMount({
-      id: 'consul'
-    });
   });
 
 });

--- a/tests/sys/keys.js
+++ b/tests/sys/keys.js
@@ -4,7 +4,6 @@ require('../helpers').should;
 var
   helpers = require('../helpers'),
   debuglog = helpers.debuglog,
-  _ = require('lodash'),
   chai = helpers.chai,
   expect = helpers.expect;
 
@@ -14,10 +13,12 @@ chai.use(helpers.cap);
 describe('keys', function () {
   var newVault = helpers.getEmptyVault();
   var myVault;
+  var myKeys;
 
   before(function () {
     return helpers.getReadyVault().then(function (vault) {
       myVault = vault;
+      myKeys = helpers.recover().keys;
     });
 
   });
@@ -83,11 +84,15 @@ describe('keys', function () {
       return newVault.updateRekey().should.be.rejectedWith(/Vault has not been initialized/);
     });
 
-    it('should resolve with instance of binded Vault', function () {
-      var existingKeys = _.cloneDeep(myVault.keys);
-      return myVault.updateRekey().then(function (vault) {
-        vault.keys.should.not.be.empty;
-        vault.keys.should.not.include.members(existingKeys);
+    it('should resolve with instance of binded Vault - complete false', function () {
+      return myVault.updateRekey({body: {key: myKeys[0]}}).then(function (data) {
+        data.complete.should.be.false;
+      });
+    });
+
+    it('should resolve with instance of binded Vault - complete true', function () {
+      return myVault.updateRekey({body: {key: myKeys[1]}}).then(function (data) {
+        data.complete.should.be.true;
       });
     });
 

--- a/tests/sys/leases.js
+++ b/tests/sys/leases.js
@@ -2,7 +2,6 @@
 require('../helpers').should;
 
 var
-  _ = require('lodash'),
   helpers = require('../helpers'),
   debuglog = helpers.debuglog,
   chai = helpers.chai,

--- a/tests/sys/policy.js
+++ b/tests/sys/policy.js
@@ -4,8 +4,6 @@ require('../helpers').should;
 var
   helpers = require('../helpers'),
   debuglog = helpers.debuglog,
-  _ = require('lodash'),
-  expect = helpers.expect,
   chai = helpers.chai;
 
 chai.use(helpers.cap);
@@ -96,9 +94,9 @@ describe('policy', function () {
 
     it('should resolve to updated list of policies - using js objects', function () {
       var policy = {
-        "path": {
-          "secret/*": {
-            "policy": "write"
+        'path': {
+          'secret/*': {
+            'policy': 'write'
           }
         }
       };
@@ -168,7 +166,6 @@ describe('policy', function () {
     });
 
     it('should resolve to updated instance with policy removed', function () {
-      var existingPolicies = _.cloneDeep(myVault.policies);
       return myVault.deletePolicy({
         id: 'other'
       }).should.be.resolved;

--- a/tests/vaulted.js
+++ b/tests/vaulted.js
@@ -45,7 +45,7 @@ describe('Vaulted', function () {
         debugflag = vault.config.get('debug');
 
       debugflag.should.equal(options.debug);
-      var options = {
+      options = {
         debug: undefined
       };
       // reset debug flag
@@ -105,26 +105,6 @@ describe('Vaulted', function () {
       myVault.headers.should.contain.keys('X-Vault-Token');
       myVault.initialized.should.be.true;
       myVault.initialized = false;
-    });
-
-    it('setKeys undefined', function () {
-      function shouldThrow() {
-        myVault.setKeys();
-      }
-      shouldThrow.should.throw(/Vault keys not provided/);
-    });
-
-    it('setKeys empty Array', function () {
-      function shouldThrow() {
-        myVault.setKeys([]);
-      }
-      shouldThrow.should.throw(/Vault keys not provided/);
-    });
-
-    it('setKeys success', function () {
-      myVault.setKeys(['xyzabc', 'abcxyz']);
-      myVault.keys.should.contain('xyzabc');
-      myVault.keys.should.contain('abcxyz');
     });
 
     it('setStatus null', function () {


### PR DESCRIPTION
unseal requires master key share as input

**BREAKING CHANGE:** Drops the capturing keys and token automatically
on init and now a master key share must be passed in. The orchestration
of calling unseal with different master key shares is now the
responsibility of the consumer just like Vault.

Also removes backing up of the token and keys as the state is no longer
held internally and no longer captured as part of `init`. The caller is
the responsible to capture information and manage directly.

Refer to `getting_started.md` for how to do `init` and `unseal`.

closes #65
