### PR TITLE
Changed env var from DOCKER_MACHINE_HOST to DOCKER_MACHINE_NAME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 VERSION := $(shell jq .version package.json)
 
-ifeq "" "$(DOCKER_MACHINE_HOST)"
-	DOCKER_MACHINE_HOST := default
+ifeq "" "$(DOCKER_MACHINE_NAME)"
+	DOCKER_MACHINE_NAME := default
 endif
 
-DOCKER_MACHINE_IP := $(shell docker-machine ip $(DOCKER_MACHINE_HOST) 2> /dev/null)
+DOCKER_MACHINE_IP := $(shell docker-machine ip $(DOCKER_MACHINE_NAME) 2> /dev/null)
 TEST_ENV := docker
 
 ifeq "" "$(DOCKER_MACHINE_IP)"


### PR DESCRIPTION
Per docs for [`docker-machine env`](https://docs.docker.com/machine/reference/env/) the environment variable responsible for the docker machine name is `DOCKER_MACHINE_NAME`.

This rename is required to be able to run `make test-local`.
