### PR TITLE
Implement transit secret backend

### DIFF
--- a/config/specs.yml
+++ b/config/specs.yml
@@ -467,3 +467,99 @@ v1:
           - name: "format"
             type: "string"
             required: false
+  transit:
+      "%s/keys/:id":
+        get:
+          id: true
+          params: []
+        post:
+          id: true
+          params:
+            - name: "derived"
+              type: "bool"
+              required: false
+            - name: "convergent_encryption"
+              type: "bool"
+              required: false
+        delete:
+          id: true
+          params: []
+      "%s/keys/:id/config":
+        post:
+          id: true
+          params:
+            - name: "min_decryption_version"
+              type: "number"
+              required: false
+            - name: "deletion_allowed"
+              type: "bool"
+              required: false
+      "%s/keys/:id/rotate":
+        post:
+          id: true
+          params: []
+      "%s/encrypt/:id":
+        post:
+          id: true
+          params:
+            - name: "plaintext"
+              type: "string"
+              required: true
+            - name: "context"
+              type: "string"
+              required: false
+            - name: "nonce"
+              type: "string"
+              required: false
+      "%s/decrypt/:id":
+        post:
+          id: true
+          params:
+            - name: "ciphertext"
+              type: "string"
+              required: true
+            - name: "context"
+              type: "string"
+              required: false
+            - name: "nonce"
+              type: "string"
+              required: false
+      "%s/rewrap/:id":
+        post:
+          id: true
+          params:
+            - name: "ciphertext"
+              type: "string"
+              required: true
+            - name: "context"
+              type: "string"
+              required: false
+            - name: "nonce"
+              type: "string"
+              required: false
+      "%s/datakey/plaintext/:id":
+        post:
+          id: true
+          params:
+            - name: "context"
+              type: "string"
+              required: false
+            - name: "nonce"
+              type: "string"
+              required: false
+            - name: "bits"
+              type: "number"
+              required: false
+      "%s/datakey/wrapped/:id":
+        post:
+          id: true
+          params:
+            - name: "context"
+              type: "string"
+              required: false
+            - name: "nonce"
+              type: "string"
+              required: false
+            - name: "bits"
+              type: "number"
+              required: false

--- a/lib/backends/transit.js
+++ b/lib/backends/transit.js
@@ -1,0 +1,317 @@
+'use strict';
+var
+  Vaulted = {},
+  Promise = require('bluebird'),
+  _ = require('lodash'),
+  utils = require('../utils');
+
+/**
+ * @module backend/transit
+ * @extends Vaulted
+ * @desc Provides implementation for the Vault Transit APIs
+ *
+ */
+
+module.exports = function extend(Proto) {
+  Vaulted.getTransitKeysEndpoint = _.partialRight(
+    _.partial(Proto.validateEndpoint, '%s/keys/:id'), 'transit');
+  Vaulted.getTransitKeysConfigEndpoint = _.partialRight(
+    _.partial(Proto.validateEndpoint, '%s/keys/:id/config'), 'transit');
+  Vaulted.getTransitKeysRotateEndpoint = _.partialRight(
+    _.partial(Proto.validateEndpoint, '%s/keys/:id/rotate'), 'transit');
+  Vaulted.getTransitEncryptEndpoint = _.partialRight(
+    _.partial(Proto.validateEndpoint, '%s/encrypt/:id'), 'transit');
+  Vaulted.getTransitDecryptEndpoint = _.partialRight(
+    _.partial(Proto.validateEndpoint, '%s/decrypt/:id'), 'transit');
+  Vaulted.getTransitRewrapEndpoint = _.partialRight(
+    _.partial(Proto.validateEndpoint, '%s/rewrap/:id'), 'transit');
+  Vaulted.getTransitPlainTextDatakeyEndpoint = _.partialRight(
+    _.partial(Proto.validateEndpoint, '%s/datakey/plaintext/:id'), 'transit');
+  Vaulted.getTransitWrappedDatakeyEndpoint = _.partialRight(
+    _.partial(Proto.validateEndpoint, '%s/datakey/wrapped/:id'), 'transit');
+  _.extend(Proto, Vaulted);
+};
+
+/**
+ * @method setTransitKey
+ * @desc Creates a new named encryption key. The values set here cannot be changed after key creation.
+ *
+ * @param {string} options.id - unique identifier for the key
+ * @param {boolean} [options.body.derived] - Boolean flag indicating if key derivation MUST be used.
+ * @param {boolean} [options.body.convergent_encryption] - If set, the key will support convergent
+ * encryption, where the same plaintext creates the same ciphertext.
+ * @param {string} [options.token] - the authentication token
+ * @param {string} [mountName=transit] - path name the transit secret backend is mounted on
+ * @resolve success
+ * @reject {Error} An error indicating what went wrong
+ * @return {Promise}
+ */
+Vaulted.setTransitKey = Promise.method(function setTransitKey(options, mountName) {
+  options = utils.setDefaults(options, {
+    derived: false,
+    convergent_encryption: false
+  });
+
+  if (options.body.convergent_encryption && !options.body.derived) {
+    return Promise.reject(new Error('Convergent encryption requires key derivation to be set'));
+  }
+
+  return this.getTransitKeysEndpoint(mountName)
+    .post({
+      headers: this.headers,
+      id: options.id,
+      body: options.body,
+      _token: options.token
+    });
+});
+
+/**
+ * @method getTransitKey
+ * @desc Returns information about a named encryption key.
+ * The keys object shows the creation time of each key version; the values
+ * are not the keys themselves.
+ *
+ * @param {string} options.id - unique identifier for the key
+ * @param {string} [options.token] - the authentication token
+ * @param {string} [mountName=transit] - path name the transit secret backend is mounted on
+ * @resolve {object} Resolves with information about the encryption key
+ * @reject {Error} An error indicating what went wrong
+ * @return {Promise}
+ */
+Vaulted.getTransitKey = Promise.method(function getTransitKey(options, mountName) {
+  options = options || {};
+
+  return this.getTransitKeysEndpoint(mountName)
+    .get({
+      headers: this.headers,
+      id: options.id,
+      _token: options.token
+    });
+});
+
+/**
+ * @method deleteTransitKey
+ * @desc Deletes a named encryption key. It will no longer be possible to decrypt
+ * any data encrypted with the named key. Because this is a potentially catastrophic
+ * operation, the deletion_allowed tunable must be set in the key's /config endpoint
+ *
+ * @param {string} options.id - unique identifier for the key
+ * @param {string} [options.token] - the authentication token
+ * @param {string} [mountName=transit] - path name the transit secret backend is mounted on
+ * @resolve success
+ * @reject {Error} An error indicating what went wrong
+ * @return {Promise}
+ */
+Vaulted.deleteTransitKey = Promise.method(function deleteTransitKey(options, mountName) {
+  options = options || {};
+
+  return this.getTransitKeysEndpoint(mountName)
+    .delete({
+      headers: this.headers,
+      id: options.id,
+      _token: options.token
+    });
+});
+
+/**
+ * @method setTransitKeyConfig
+ * @desc Allows tuning configuration values for a given key. (These values are returned
+ * during a read operation on the named key.)
+ *
+ * @param {string} options.id - unique identifier for the key
+ * @param {number} [options.body.min_decryption_version] - The minimum version of ciphertext allowed to be decrypted.
+ * @param {boolean} [options.body.deletion_allowed] - When set, the key is allowed to be deleted.
+ * @param {string} [options.token] - the authentication token
+ * @param {string} [mountName=transit] - path name the transit secret backend is mounted on
+ * @resolve success
+ * @reject {Error} An error indicating what went wrong
+ * @return {Promise}
+ */
+Vaulted.setTransitKeyConfig = Promise.method(function setTransitKeyConfig(options, mountName) {
+  options = utils.setDefaults(options, {
+    min_decryption_version: 0,
+    deletion_allowed: false
+  });
+
+  return this.getTransitKeysConfigEndpoint(mountName)
+    .post({
+      body: options.body,
+      headers: this.headers,
+      id: options.id,
+      _token: options.token
+    });
+});
+
+/**
+ * @method rotateTransitKey
+ * @desc Rotates the version of the named key. After rotation, new plaintext requests will
+ * be encrypted with the new version of the key. To upgrade ciphertext to be encrypted
+ * with the latest version of the key, use the rewrap endpoint.
+ *
+ * @param {string} options.id - unique identifier for the key
+ * @param {string} [options.token] - the authentication token
+ * @param {string} [mountName=transit] - path name the transit secret backend is mounted on
+ * @resolve success
+ * @reject {Error} An error indicating what went wrong
+ * @return {Promise}
+ */
+Vaulted.rotateTransitKey = Promise.method(function rotateTransitKey(options, mountName) {
+  options = options || {};
+
+  return this.getTransitKeysRotateEndpoint(mountName)
+    .post({
+      headers: this.headers,
+      id: options.id,
+      _token: options.token
+    });
+});
+
+/**
+ * @method encryptTransitPlainText
+ * @desc Encrypts the provided plaintext using the named key. This path supports the create and
+ * update policy capabilities as follows: if the user has the create capability for this endpoint
+ * in their policies, and the key does not exist, it will be upserted with default values
+ * (whether the key requires derivation depends on whether the context parameter is empty or
+ * not). If the user only has update capability and the key does not exist, an error will be returned.
+ *
+ * @param {string} options.id - unique identifier for the key
+ * @param {string} options.body.plaintext - The plaintext to encrypt, provided as base64 encoded
+ * @param {string} [options.body.context] - The key derivation context, provided as base64 encoded.
+ * Must be provided if derivation is enabled.
+ * @param {string} [options.body.nonce] - The nonce value, provided as base64 encoded. Must be
+ * provided if convergent encryption is enabled for this key.
+ * @param {string} [options.token] - the authentication token
+ * @param {string} [mountName=transit] - path name the transit secret backend is mounted on
+ * @resolve {object} Resolves with the encrypted ciphertext output
+ * @reject {Error} An error indicating what went wrong
+ * @return {Promise}
+ */
+Vaulted.encryptTransitPlainText = Promise.method(function encryptTransitPlainText(options, mountName) {
+  options = options || {};
+
+  return this.getTransitEncryptEndpoint(mountName)
+  .post({
+    body: options.body,
+    headers: this.headers,
+    id: options.id,
+    _token: options.token
+  });
+});
+
+/**
+ * @method decryptTransitCipherText
+ * @desc Decrypts the provided ciphertext using the named key.
+ *
+ * @param {string} options.id - unique identifier for the key
+ * @param {string} options.body.ciphertext - The ciphertext to decrypt, provided as returned by encrypt.
+ * @param {string} [options.body.context] - The key derivation context, provided as base64 encoded.
+ * Must be provided if derivation is enabled.
+ * @param {string} [options.body.nonce] - The nonce value, provided as base64 encoded. Must be
+ * provided if convergent encryption is enabled for this key.
+ * @param {string} [options.token] - the authentication token
+ * @param {string} [mountName=transit] - path name the transit secret backend is mounted on
+ * @resolve {object} Resolves with the decrypted plaintext output
+ * @reject {Error} An error indicating what went wrong
+ * @return {Promise}
+ */
+Vaulted.decryptTransitCipherText = Promise.method(function decryptTransitCipherText(options, mountName) {
+  options = options || {};
+
+  return this.getTransitDecryptEndpoint(mountName)
+    .post({
+      body: options.body,
+      headers: this.headers,
+      id: options.id,
+      _token: options.token
+    });
+});
+
+/**
+ * @method rewrapTransitCipherText
+ * @desc Rewrap the provided ciphertext using the latest version of the named key.
+ *
+ * @param {string} options.id - unique identifier for the key
+ * @param {string} options.body.ciphertext - The ciphertext to decrypt, provided as returned by encrypt.
+ * @param {string} [options.body.context] - The key derivation context, provided as base64 encoded.
+ * Must be provided if derivation is enabled.
+ * @param {string} [options.body.nonce] - The nonce value, provided as base64 encoded. Must be
+ * provided if convergent encryption is enabled for this key.
+ * @param {string} [options.token] - the authentication token
+ * @param {string} [mountName=transit] - path name the transit secret backend is mounted on
+ * @resolve {object} Resolves with the decrypted plaintext output
+ * @reject {Error} An error indicating what went wrong
+ * @return {Promise}
+ */
+Vaulted.rewrapTransitCipherText = Promise.method(function rewrapTransitCipherText(options, mountName) {
+  options = options || {};
+
+  return this.getTransitRewrapEndpoint(mountName)
+    .post({
+      body: options.body,
+      headers: this.headers,
+      id: options.id,
+      _token: options.token
+    });
+});
+
+/**
+ * @method generateTransitPlainTextDataKey
+ * @desc Generate a new high-entropy key, the value encrypted with the named key, and the plaintext of the key.
+ *
+ * @param {string} options.id - unique identifier for the key
+ * @param {string} [options.body.context] - The key derivation context, provided as base64 encoded.
+ * Must be provided if derivation is enabled.
+ * @param {string} [options.body.nonce] - The nonce value, provided as base64 encoded. Must be provided
+ * if convergent encryption is enabled for this key.
+ * @param {number} [option.body.bits] - The number of bits in the desired key. Can be 128, 256, or 512.
+ * @param {string} [options.token] - the authentication token
+ * @param {string} [mountName=transit] - path name the transit secret backend is mounted on
+ * @resolve {object} Resolves with a new key and the value encrypted with the named key.
+ * @reject {Error} An error indicating what went wrong
+ * @return {Promise}
+ */
+Vaulted.generateTransitPlainTextDataKey = Promise.method(function generateTransitPlainTextDataKey (options, mountName) {
+  options = utils.setDefaults(options, {
+    bits: 256
+  });
+
+  return this.getTransitPlainTextDatakeyEndpoint(mountName)
+    .post({
+      body: options.body,
+      headers: this.headers,
+      format: options.format,
+      id: options.id,
+      _token: options.token
+    });
+});
+
+/**
+ * @method generateTransitWrappedDataKey
+ * @desc Generate a new high-entropy key and the value encrypted with the named key.
+ *
+ * @param {string} options.id - unique identifier for the key
+ * @param {string} [options.body.context] - The key derivation context, provided as base64 encoded.
+ * Must be provided if derivation is enabled.
+ * @param {string} [options.body.nonce] - The nonce value, provided as base64 encoded. Must be provided
+ * if convergent encryption is enabled for this key.
+ * @param {number} [option.body.bits] - The number of bits in the desired key. Can be 128, 256, or 512.
+ * @param {string} [options.token] - the authentication token
+ * @param {string} [mountName=transit] - path name the transit secret backend is mounted on
+ * @resolve {object} Resolves with a new key and, optionally, the value encrypted with the named key.
+ * @reject {Error} An error indicating what went wrong
+ * @return {Promise}
+ */
+Vaulted.generateTransitWrappedDataKey = Promise.method(function generateTransitWrappedDataKey(options, mountName) {
+  options = utils.setDefaults(options, {
+    bits: 256
+  });
+
+  return this.getTransitWrappedDatakeyEndpoint(mountName)
+    .post({
+      body: options.body,
+      headers: this.headers,
+      format: options.format,
+      id: options.id,
+      _token: options.token
+    });
+});

--- a/lib/sys/mounts.js
+++ b/lib/sys/mounts.js
@@ -230,3 +230,29 @@ Vaulted.mountPki = Promise.method(function mountPki(options) {
     token: options.token
   });
 });
+
+/**
+* @method mountTransit
+* @desc Convenience method to enable the `transit` secret backend for use with the vault.
+*
+* @param {string} [options.id=transit] - unique identifier for the secret backend mount
+* @param {string} [options.body.description] - a description of the secret backend for operators.
+* @param {string} [options.token] - the authentication token
+* @resolve {[Mounts]} Resolves with current list of mounted secret backends
+* @reject {Error} An error indicating what went wrong
+* @return {Promise}
+*/
+Vaulted.mountTransit = Promise.method(function mountTransit(options) {
+  options = utils.setDefaults(options);
+  options.id = options.id || 'transit';
+  options.body = _.defaults(options.body, {
+    type: 'transit',
+    description: 'Transit Secrets Backend ' + options.id
+  });
+
+  return this.createMount({
+    id: options.id,
+    body: options.body,
+    token: options.token
+  });
+});

--- a/lib/vaulted.js
+++ b/lib/vaulted.js
@@ -158,6 +158,7 @@ require('./backends/secret')(Vaulted.prototype);
 require('./backends/cubbyhole')(Vaulted.prototype);
 require('./backends/consul')(Vaulted.prototype);
 require('./backends/pki')(Vaulted.prototype);
+require('./backends/transit')(Vaulted.prototype);
 
 // internal events
 require('./listeners')(Vaulted.prototype);

--- a/tests/backends/transit.js
+++ b/tests/backends/transit.js
@@ -1,0 +1,593 @@
+'use strict';
+require('../helpers').should;
+
+var
+  fs = require('fs'),
+  path = require('path'),
+  helpers = require('../helpers'),
+  debuglog = helpers.debuglog,
+  chai = helpers.chai,
+  expect = helpers.expect;
+
+chai.use(helpers.cap);
+
+var testVaultErrors = function (err, expected) {
+  expect(err).not.to.be.undefined;
+  err.should.have.property('error');
+  expect(err.error).not.to.be.undefined;
+  expect(err.error).not.to.be.null;
+  err.error.should.have.property('errors');
+  expect(err.error.errors).not.to.be.undefined;
+  expect(err.error.errors).not.to.be.null;
+  err.error.errors.should.be.instanceof(Array);
+  err.error.errors.length.should.equal(1);
+  expect(err.error.errors[0]).not.to.be.undefined;
+  expect(err.error.errors[0]).not.to.be.null;
+  err.error.errors[0].should.match(expected);
+};
+
+describe('transit', function () {
+  var newVault = helpers.getEmptyVault();
+  var myVault;
+
+  before(function () {
+    return helpers.getReadyVault().then(function (vault) {
+      myVault = vault;
+      return myVault.mountTransit();
+    });
+  });
+
+  describe('#setTransitKey', function () {
+
+    it('should reject with an Error if not initialized or unsealed', function () {
+      return newVault.setTransitKey({
+        id: 'sample'
+      }).should.be.rejectedWith(/Vault has not been initialized/);
+    });
+
+    it('should reject with an Error if convergent encryption is set and key derivation is not', function () {
+      return myVault.setTransitKey({
+        id: 'sample',
+        body: {
+          convergent_encryption: true
+        }
+      }).should.be.rejectedWith(/Convergent encryption requires key derivation to be set/);
+    });
+
+    it('should reject with an Error if no key name is provided', function () {
+      return myVault.setTransitKey().should.be.rejectedWith(/requires an id/);
+    });
+
+    it('should create a new named encryption key', function () {
+      return myVault.setTransitKey({
+        id: 'sample'
+      }).then(function () {
+        return myVault.getTransitKey({id: 'sample'}).should.not.be.rejected;
+      });
+    });
+  });
+
+  describe('#getTransitKey', function () {
+
+    it('should reject with an Error if not initialized or unsealed', function () {
+      return newVault.setTransitKey({id: 'sample'}).should.be.rejectedWith(/Vault has not been initialized/);
+    });
+
+    it('should reject with an Error if no key name is provided', function () {
+      return myVault.getTransitKey().should.be.rejectedWith(/requires an id/);
+    });
+
+    it('should reject with an Error if the requested key does not exist', function () {
+      return myVault.getTransitKey({id: 'foo'}).should.be.rejectedWith(/404/);
+    });
+
+    it('should resolve with information about the encryption key', function () {
+      return myVault.getTransitKey({
+        id: 'sample'
+      }).then(function(key) {
+        debuglog(key);
+        expect(key).not.to.be.undefined;
+        key.should.have.property('data');
+        expect(key.data).not.to.be.undefined;
+        expect(key.data).not.to.be.null;
+        key.data.should.have.property('cipher_mode');
+        key.data.should.have.property('deletion_allowed');
+        key.data.should.have.property('derived');
+        key.data.should.have.property('min_decryption_version');
+        key.data.should.have.property('name');
+        key.data.should.have.property('keys');
+        expect(key.data.keys).not.to.be.undefined;
+        expect(key.data.keys).not.to.be.null;
+        Object.keys(key.data.keys).length.should.be.above(0);
+      });
+    });
+  });
+
+  describe('#deleteTransitKey', function () {
+
+    it('should reject with an Error if not initialized or unsealed', function () {
+      return newVault.deleteTransitKey({id: 'sample'}).should.be.rejectedWith(/Vault has not been initialized/);
+    });
+
+    it('should reject with an Error if no key name is provided', function () {
+      return myVault.deleteTransitKey().should.be.rejectedWith(/requires an id/);
+    });
+
+    it('should reject with an Error if the requested key does not exist', function () {
+      return myVault.deleteTransitKey({id: 'foo'}).catch(function (err) {
+        debuglog(err);
+        return testVaultErrors(err, /could not delete policy; not found/);
+      });
+    });
+
+    it('should not be able to delete the named key by default (deletion_allowed = false)', function () {
+      return myVault.deleteTransitKey({id: 'sample'}).catch(function (err) {
+        debuglog(err);
+        return testVaultErrors(err, /deletion is not allowed for this policy/);
+      });
+    });
+
+    before(function () {
+      return myVault.setTransitKey({id: 'tobedeleted'}).then(function() {
+        return myVault.setTransitKeyConfig({
+          id: 'tobedeleted',
+          body: {
+            deletion_allowed: true
+          }
+        });
+      });
+    });
+
+    it('should be able to delete the named key if deletion_enabled = true', function () {
+      return myVault.deleteTransitKey({id: 'tobedeleted'}).then(function () {
+        return myVault.getTransitKey({id: 'tobedeleted'}).should.be.rejectedWith(/404/);
+      });
+    });
+  });
+
+  describe('#setTransitKeyConfig', function () {
+
+    it('should reject with an Error if not initialized or unsealed', function () {
+      return newVault.setTransitKeyConfig({id: 'sample'}).should.be.rejectedWith(/Vault has not been initialized/);
+    });
+
+    it('should reject with an Error if no key name is provided', function () {
+      return myVault.setTransitKeyConfig().should.be.rejectedWith(/requires an id/);
+    });
+
+    it('should reject with an Error if the requested key does not exist', function () {
+      return myVault.setTransitKeyConfig({id: 'foo'}).catch(function (err) {
+        debuglog(err);
+        return testVaultErrors(err, /no existing key named foo could be found/);
+      });
+    });
+
+    it('should update the key configuration if a config value is changed', function () {
+      return myVault.getTransitKey({id: 'sample'}).then(function (key) {
+        debuglog(key);
+        expect(key).not.to.be.undefined;
+        key.should.have.property('data');
+        expect(key.data).not.to.be.undefined;
+        expect(key.data).not.to.be.null;
+        key.data.should.have.property('deletion_allowed');
+        key.data.deletion_allowed.should.equal(false);
+      }).then(function() {
+        return myVault.setTransitKeyConfig({
+          id: 'sample',
+          body: {
+            deletion_allowed: true
+          }
+        }).then(function () {
+          return myVault.getTransitKey({id: 'sample'}).then(function (key) {
+            debuglog(key);
+            expect(key).not.to.be.undefined;
+            key.should.have.property('data');
+            expect(key.data).not.to.be.undefined;
+            expect(key.data).not.to.be.null;
+            key.data.should.have.property('deletion_allowed');
+            key.data.deletion_allowed.should.equal(true);
+          })
+        });
+      });
+    });
+  });
+
+  describe('#rotateTransitKey', function () {
+
+    before(function () {
+      return myVault.setTransitKey({id: 'rotatingkey'}).then(function () {
+        return myVault.setTransitKeyConfig({
+          id: 'rotatingkey',
+          body: {
+            deletion_allowed: true
+          }
+        })
+      });
+    });
+
+    after(function () {
+      return myVault.deleteTransitKey({id: 'rotatingkey'});
+    });
+
+    it('should reject with an Error if not initialized or unsealed', function () {
+      return newVault.rotateTransitKey({id: 'rotatingkey'}).should.be.rejectedWith(/Vault has not been initialized/);
+    });
+
+    it('should reject with an Error if no key name is provided', function () {
+      return myVault.rotateTransitKey().should.be.rejectedWith(/requires an id/);
+    });
+
+    it('should rotate the named key to a new version', function () {
+      return myVault.getTransitKey({id: 'rotatingkey'})
+        .then(function (key) {
+          debuglog(key);
+          expect(key).not.to.be.undefined;
+          key.should.have.property('data');
+          expect(key.data).not.to.be.undefined;
+          expect(key.data).not.to.be.null;
+          key.data.should.have.property('keys');
+          key.data.should.have.property('latest_version');
+          key.data.latest_version.should.equal(1);
+          Object.keys(key.data.keys).length.should.equal(1);
+        }).then(function () {
+          return myVault.rotateTransitKey({id: 'rotatingkey'});
+        }).then(function () {
+          return myVault.getTransitKey({id: 'rotatingkey'});
+        }).then(function (rotatedKey) {
+          debuglog(rotatedKey);
+          expect(rotatedKey).not.to.be.undefined;
+          rotatedKey.should.have.property('data');
+          expect(rotatedKey.data).not.to.be.undefined;
+          expect(rotatedKey.data).not.to.be.null;
+          rotatedKey.data.should.have.property('keys');
+          rotatedKey.data.should.have.property('latest_version');
+          rotatedKey.data.latest_version.should.equal(2);
+          Object.keys(rotatedKey.data.keys).length.should.equal(2);
+        });
+    });
+  });
+
+  describe('#encryptTransitPlainText', function () {
+    before(function () {
+      return myVault.setTransitKey({id: 'encryptingkey'}).then(function () {
+        return myVault.setTransitKeyConfig({
+          id: 'encryptingkey',
+          body: {
+            deletion_allowed: true
+          }
+        })
+      });
+    });
+
+    after(function () {
+      return myVault.deleteTransitKey({id: 'encryptingkey'});
+    });
+
+    it('should reject with an Error if not initialized or unsealed', function () {
+      return newVault.encryptTransitPlainText({id: 'encryptingkey'}).should.be.rejectedWith(/Vault has not been initialized/);
+    });
+
+    it('should reject with an Error if no key name is provided', function () {
+      return myVault.encryptTransitPlainText().should.be.rejectedWith(/requires an id/);
+    });
+
+    it('should reject with an Error if no plaintext is provided', function () {
+      return myVault.encryptTransitPlainText({id: 'encryptingkey'}).should.be.rejectedWith(/Missing required input plaintext/);
+    });
+
+    it('should reject with an Error if the plaintext is not base64 encoded', function () {
+      return myVault.encryptTransitPlainText({
+        id: 'encryptingkey',
+        body: {
+          plaintext: 'notencodedatall!'
+        }
+      }).catch(function (err) {
+        debuglog(err);
+        return testVaultErrors(err, /failed to decode plaintext as base64/);
+      });
+    });
+
+    it('should resolve with an object containing the encrypted plaintext as ciphertext', function () {
+      return myVault.encryptTransitPlainText({
+        id: 'encryptingkey',
+        body: {
+          plaintext: 'dGhpc2lzc29tZXJlYWxseWxvbmdwYXNzd29yZG9yc29tZXRoaW5n'
+        }
+      }).then(function (encryptedText) {
+        debuglog(encryptedText);
+        expect(encryptedText).not.to.be.undefined;
+        encryptedText.should.have.property('data');
+        expect(encryptedText.data).not.to.be.undefined;
+        expect(encryptedText.data).not.to.be.null;
+        encryptedText.data.should.have.property('ciphertext');
+        encryptedText.data.ciphertext.should.match(/vault:v1/);
+      });
+    });
+  });
+
+  describe('#decryptTransitCipherText', function () {
+    var plaintext = new Buffer('somesecretthatwereallyneed').toString('base64');
+    var ciphertext;
+
+    before(function () {
+      return myVault.setTransitKey({id: 'decryptingkey'}).then(function () {
+        return myVault.setTransitKeyConfig({id: 'decryptingkey', body: {deletion_allowed: true}})
+      }).then(function () {
+        return myVault.encryptTransitPlainText({id: 'decryptingkey', body: {plaintext: plaintext}});
+      }).then(function (key) {
+        ciphertext = key.data.ciphertext;
+      });
+    });
+
+    after(function () {
+      return myVault.deleteTransitKey({id: 'decryptingkey'});
+    });
+
+    it('should reject with an Error if not initialized or unsealed', function () {
+      return newVault.decryptTransitCipherText({id: 'decryptingkey'}).should.be.rejectedWith(/Vault has not been initialized/);
+    });
+
+    it('should reject with an Error if no key name is provided', function () {
+      return myVault.decryptTransitCipherText().should.be.rejectedWith(/requires an id/);
+    });
+
+    it('should reject with an Error if no ciphertext is provided', function () {
+      return myVault.decryptTransitCipherText({id: 'decryptingkey'}).should.be.rejectedWith(/Missing required input ciphertext/);
+    });
+
+    it('should reject with an Error if the provided ciphertext is invalid', function () {
+      return myVault.decryptTransitCipherText({
+        id: 'decryptingkey',
+        body: {
+          ciphertext: 'foobarbaz'
+        }
+      }).catch(function (err) {
+        debuglog(err);
+        return testVaultErrors(err, /invalid ciphertext: no prefix/);
+      });
+    });
+
+    it('should reject with an Error if the provided ciphertext has a valid prefix but is invalid', function () {
+      return myVault.decryptTransitCipherText({
+        id: 'decryptingkey',
+        body: {
+          ciphertext: 'vault:v1:foobarbaz'
+        }
+      }).catch(function (err) {
+        debuglog(err);
+        return testVaultErrors(err, /invalid ciphertext: could not decode base64/);
+      });
+    });
+
+    it('should reject with an Error if the provided ciphertext has a valid prefix and the body is base64 encoded but' +
+      ' it is not a valid ciphertext', function () {
+      var encodedBadCipherText = new Buffer('foobarbaz').toString('base64');
+
+      return myVault.decryptTransitCipherText({
+        id: 'decryptingkey',
+        body: {
+          ciphertext: 'vault:v1:' + encodedBadCipherText
+        }
+      }).should.be.rejectedWith(/socket hang up/);
+    });
+
+    it('should resolve with an object containing the decrypted ciphertext as plaintext', function () {
+      return myVault.decryptTransitCipherText({
+        id: 'decryptingkey',
+        body: {
+          ciphertext: ciphertext
+        }
+      }).then(function (decryptedText) {
+        debuglog(decryptedText);
+        expect(decryptedText).not.to.be.undefined;
+        decryptedText.should.have.property('data');
+        expect(decryptedText.data).not.to.be.undefined;
+        expect(decryptedText.data).not.to.be.null;
+        decryptedText.data.should.have.property('plaintext');
+
+        var secret = new Buffer(decryptedText.data.plaintext, 'base64').toString();
+        secret.should.equal('somesecretthatwereallyneed');
+      });
+    })
+  });
+
+  describe('#rewrapTransitCipherText', function () {
+
+    var plaintext = new Buffer('somesecretthatwereallyneed').toString('base64');
+    var ciphertext;
+
+    before(function () {
+      return myVault.setTransitKey({id: 'rewrappingkey'}).then(function () {
+        return myVault.setTransitKeyConfig({id: 'rewrappingkey', body: {deletion_allowed: true}})
+      }).then(function () {
+        return myVault.encryptTransitPlainText({id: 'rewrappingkey', body: {plaintext: plaintext}});
+      }).then(function (key) {
+        ciphertext = key.data.ciphertext;
+      });
+    });
+
+    after(function () {
+      return myVault.deleteTransitKey({id: 'rewrappingkey'});
+    });
+
+    it('should reject with an Error if not initialized or unsealed', function () {
+      return newVault.rewrapTransitCipherText({id: 'rewrappingkey'}).should.be.rejectedWith(/Vault has not been initialized/);
+    });
+
+    it('should reject with an Error if no key name is provided', function () {
+      return myVault.rewrapTransitCipherText().should.be.rejectedWith(/requires an id/);
+    });
+
+    it('should reject with an Error if no ciphertext is provided', function () {
+      return myVault.rewrapTransitCipherText({id: 'rewrappingkey'}).should.be.rejectedWith(/Missing required input ciphertext/);
+    });
+
+    it('should reject with an Error if the provided ciphertext is invalid', function () {
+      return myVault.rewrapTransitCipherText({
+        id: 'rewrappingkey',
+        body: {
+          ciphertext: 'foobarbaz'
+        }
+      }).catch(function (err) {
+        debuglog(err);
+        return testVaultErrors(err, /invalid ciphertext: no prefix/);
+      });
+    });
+
+    it('should reject with an Error if the provided ciphertext has a valid prefix but is invalid', function () {
+      return myVault.rewrapTransitCipherText({
+        id: 'rewrappingkey',
+        body: {
+          ciphertext: 'vault:v1:foobarbaz'
+        }
+      }).catch(function (err) {
+        debuglog(err);
+        return testVaultErrors(err, /invalid ciphertext: could not decode base64/);
+      });
+    });
+
+    it('should reject with an Error if the provided ciphertext has a valid prefix and the body is base64 encoded but' +
+      ' it is not a valid ciphertext', function () {
+      var encodedBadCipherText = new Buffer('foobarbaz').toString('base64');
+
+      return myVault.rewrapTransitCipherText({
+        id: 'rewrappingkey',
+        body: {
+          ciphertext: 'vault:v1:' + encodedBadCipherText
+        }
+      }).should.be.rejectedWith(/socket hang up/);
+    });
+
+    it('should resolve with an object containing the rewrapped key', function () {
+      return myVault.rewrapTransitCipherText({
+        id: 'rewrappingkey',
+        body: {
+          ciphertext: ciphertext
+        }
+      }).then(function (reWrappedText) {
+        debuglog(reWrappedText);
+        expect(reWrappedText).not.to.be.undefined;
+        reWrappedText.should.have.property('data');
+        expect(reWrappedText.data).not.to.be.undefined;
+        expect(reWrappedText.data).not.to.be.null;
+        reWrappedText.data.should.have.property('ciphertext');
+        reWrappedText.data.ciphertext.should.not.equal(ciphertext);
+      }).then(function () {
+        return myVault.decryptTransitCipherText({
+          id: 'rewrappingkey',
+          body: {
+            ciphertext: ciphertext
+          }
+        });
+      }).then(function (decryptedText) {
+        debuglog(decryptedText);
+        expect(decryptedText).not.to.be.undefined;
+        decryptedText.should.have.property('data');
+        expect(decryptedText.data).not.to.be.undefined;
+        expect(decryptedText.data).not.to.be.null;
+        decryptedText.data.should.have.property('plaintext');
+
+        var secret = new Buffer(decryptedText.data.plaintext, 'base64').toString();
+        secret.should.equal('somesecretthatwereallyneed');
+      });
+    });
+  });
+
+  describe('#generateTransitPlainTextDataKey', function () {
+
+    var plaintext = new Buffer('somesecretthatwereallyneed').toString('base64');
+    var ciphertext;
+
+    before(function () {
+      return myVault.setTransitKey({id: 'datakey'}).then(function () {
+        return myVault.setTransitKeyConfig({id: 'datakey', body: {deletion_allowed: true}})
+      }).then(function () {
+        return myVault.encryptTransitPlainText({id: 'datakey', body: {plaintext: plaintext}});
+      }).then(function (key) {
+        ciphertext = key.data.ciphertext;
+      });
+    });
+
+    after(function () {
+      return myVault.deleteTransitKey({id: 'datakey'});
+    });
+
+    it('should reject with an Error if not initialized or unsealed', function () {
+      return newVault.generateTransitPlainTextDataKey({id: 'datakey'}).should.be.rejectedWith(/Vault has not been initialized/);
+    });
+
+    it('should reject with an Error if no key name is provided', function () {
+      return myVault.generateTransitPlainTextDataKey().should.be.rejectedWith(/requires an id/);
+    });
+
+    it('should reject with an Error if the id is not found', function () {
+      return myVault.generateTransitPlainTextDataKey({id: 'rewrappingkey'})
+        .catch(function (err) {
+          debuglog(err);
+          return testVaultErrors(err, /policy not found/);
+        });
+    });
+
+    it('should resolve with a new key and its plaintext value', function () {
+      return myVault.generateTransitPlainTextDataKey({id: 'datakey'})
+        .then(function (key) {
+          debuglog(key);
+          expect(key).not.to.be.undefined;
+          key.should.have.property('data');
+          expect(key.data).not.to.be.undefined;
+          expect(key.data).not.to.be.null;
+          key.data.should.have.property('ciphertext');
+          key.data.should.have.property('plaintext');
+        });
+    });
+  });
+
+  describe('#generateTransitWrappedDataKey', function () {
+
+    var plaintext = new Buffer('somesecretthatwereallyneed').toString('base64');
+    var ciphertext;
+
+    before(function () {
+      return myVault.setTransitKey({id: 'datakey'}).then(function () {
+        return myVault.setTransitKeyConfig({id: 'datakey', body: {deletion_allowed: true}})
+      }).then(function () {
+        return myVault.encryptTransitPlainText({id: 'datakey', body: {plaintext: plaintext}});
+      }).then(function (key) {
+        ciphertext = key.data.ciphertext;
+      });
+    });
+
+    after(function () {
+      return myVault.deleteTransitKey({id: 'datakey'});
+    });
+
+    it('should reject with an Error if not initialized or unsealed', function () {
+      return newVault.generateTransitWrappedDataKey({id: 'datakey'}).should.be.rejectedWith(/Vault has not been initialized/);
+    });
+
+    it('should reject with an Error if no key name is provided', function () {
+      return myVault.generateTransitWrappedDataKey().should.be.rejectedWith(/requires an id/);
+    });
+
+    it('should reject with an Error if the id is not found', function () {
+      return myVault.generateTransitWrappedDataKey({id: 'rewrappingkey'})
+        .catch(function (err) {
+          debuglog(err);
+          return testVaultErrors(err, /policy not found/);
+        });
+    });
+
+    it('should resolve with a new key and its plaintext value', function () {
+      return myVault.generateTransitWrappedDataKey({id: 'datakey'})
+        .then(function (key) {
+          debuglog(key);
+          expect(key).not.to.be.undefined;
+          key.should.have.property('data');
+          expect(key.data).not.to.be.undefined;
+          expect(key.data).not.to.be.null;
+          key.data.should.have.property('ciphertext');
+          key.data.should.not.have.property('plaintext');
+        });
+    });
+  });
+});


### PR DESCRIPTION
This PR implements the [Transit](https://www.vaultproject.io/docs/secrets/transit/) secret backend.

There are no features or tests around the use of `derived` keys,`convergent_encryption`, key derivation `context`, and `nonce` values. It is assumed that Vault will handle errors in calls when a named key is created with key derivation or convergent encryption and then `context` and `nonce` params are not specified on the request body.

This makes some progress towards #84.
