### PR TITLE
if mount<backend> is called, confirm that the backend isn't mounted yet before mounting it.

### DIFF
--- a/lib/sys/mounts.js
+++ b/lib/sys/mounts.js
@@ -84,18 +84,30 @@ Vaulted.deleteMount = Promise.method(function deleteMount(options) {
  */
 Vaulted.createMount = Promise.method(function createMount(options) {
   options = utils.setDefaults(options);
-  return this.getMountsEndpoint()
-    .post({
-      headers: this.headers,
-      id: options.id,
-      body: options.body,
-      _token: options.token
-    })
-    .promise()
+
+  return this.getMounts({token: options.token})
     .bind(this)
-    .then(function () {
-      this.emit('mount', options.body.type, options.id);
-      return this.getMounts({token: options.token});
+    .then(function (mounts) {
+      // Check if already mounted
+      if (_.has(mounts, options.id + '/')) {
+        // If so, load the API specs for the endpoint and return the complete list of mounts
+        this.emit('mount', options.body.type, options.id);
+        return mounts;
+      }
+      // Otherwise, mount the endpoint and then load the API specs
+      return this.getMountsEndpoint()
+        .post({
+          headers: this.headers,
+          id: options.id,
+          body: options.body,
+          _token: options.token
+        })
+        .promise()
+        .bind(this)
+        .then(function () {
+          this.emit('mount', options.body.type, options.id);
+          return this.getMounts({token: options.token});
+        });
     });
 });
 

--- a/tests/backends/transit.js
+++ b/tests/backends/transit.js
@@ -37,6 +37,28 @@ describe('transit', function () {
     });
   });
 
+  describe('Mount transit endpoint', function () {
+
+    it('should mount the transit endpoint', function () {
+      return helpers.getReadyVault().then(function (vault) {
+        return vault.mountTransit();
+      }).then(function (mounts) {
+        expect(mounts).to.have.property('transit/');
+      });
+    });
+
+    it('should no-op if the transit endpoint is already mounted', function () {
+      var localVault;
+
+      return helpers.getReadyVault().then(function (vault) {
+        localVault = vault;
+        return localVault.mountTransit();
+      }).then(function () {
+        return localVault.mountTransit().should.not.be.rejected;
+      });
+    });
+  });
+
   describe('#setTransitKey', function () {
 
     it('should reject with an Error if not initialized or unsealed', function () {


### PR DESCRIPTION
This PR makes mounting a previously mounted backend a no-op. This resolves #94.

Previously if a backend (like transit) is mounted before Vaulted is used, a call to `mountTransit` would throw an error because Vault would complain that the backend was already mounted. A side effect of this behavior is that the API specs for that backend wouldn't be loaded.

Now, the `mount<backend>` function is short-circuited if the requested backend is already mounted. Instead, we emit the `mount` event to load the API specs, then return the list of mounts which matches the previous behavior.
