### PR TITLE
Vaulted.prepare should synchronizes mounts

### DIFF
--- a/lib/vaulted.js
+++ b/lib/vaulted.js
@@ -61,7 +61,10 @@ util.inherits(Vaulted, events.EventEmitter);
  * @return {Promise}
  */
 Vaulted.prototype.prepare = function prepare(vault_token) {
-  return internal.loadState(this, vault_token);
+  return internal.loadState(this, vault_token).then(function (vault) {
+    internal.syncMounts(vault);
+    return vault;
+  });
 };
 
 /**

--- a/tests/backends/transit.js
+++ b/tests/backends/transit.js
@@ -37,6 +37,15 @@ describe('transit', function () {
     });
   });
 
+  describe('Mount transit endpoint', function () {
+
+    it('should mount the transit endpoint', function () {
+      return helpers.getReadyVault().then(function (vault) {
+        expect(vault.mounts).to.have.property('transit/');
+      });
+    });
+  });
+
   describe('#setTransitKey', function () {
 
     it('should reject with an Error if not initialized or unsealed', function () {


### PR DESCRIPTION
This PR is a refactor of the intent in #95 and addresses the issue raised in #94. 

Backends can be mounted out of band and Vaulted will pick up those changes whenever it is `prepare`d.
